### PR TITLE
Add --fastq-end and use only tab files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
+# mpmachado_stuff - files or directories with different mpmachado stuff
+mpmachado_stuff.*
+
 *.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 # mpmachado_stuff - files or directories with different mpmachado stuff
 mpmachado_stuff.*
 
-*.pyc
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To upload your files to ENA, you will need the following:
 2. A csv (comma separated values) file that contains all the information for each of your samples.  The text file should contain four required columns.  You may add as many columns of data as you wish after the fourth required column.  The columns are separated by commas.  e.g. (note the headings are required as seen below):
 
 
-  SAMPLE,TAXON_ID,SCIENTIFIC_NAME,DESCRIPTION
+  sample_name, taxon, organism, description
 
   data....
 
@@ -162,10 +162,10 @@ You should familarise yourself with the other options before you begin running t
     --data_file DATA_FILE, -f DATA_FILE
                           data_file, file : this text file must have at least
                           four columns seperated by TABS in the following order
-                          and with the following headings: Column 1: SAMPLE,
-                          Column 2: TAXON_ID, Column 3: SCIENTIFIC_NAME, Column
-                          4: DESCRIPTION. If you like to add further data then
-                          add it after the DESCRIPTION column.
+                          and with the following headings: Column 1: sample_name,
+                          Column 2: taxon, Column 3: organism,
+                          Column 4: description. If you like to add further data
+                          then add it after the description column.
     --ftp_user_name FTP_USER_NAME, -user FTP_USER_NAME
                           please provide the ftp user name
     --ftp_password FTP_PASSWORD, -pass FTP_PASSWORD
@@ -225,6 +225,15 @@ You should familarise yourself with the other options before you begin running t
                           you can provide two strings containing the end of
                           fastq files names (for example, "_1.fastq.gz" and
                           "_2.fastq.gz")
+    --sample_checklist ERC000029
+                          ENA provides sample checklists which define all the
+                          mandatory and recommended attributes for specific types
+                          of samples. By declaring that you would like to
+                          register your samples using a specific checklist you
+                          are enabling the samples to be validated for
+                          correctness at submission time and are making it easier
+                          for other services to find and access the sample
+                          attribute information.
 
 
 ## Contact

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ To upload your files to ENA, you will need the following:
   MN127.R1.fastq.gz
   
   MN127.R2.fastq.gz
+  
+  If your files end differently (from ".R1.fastq.gz" and ".R2.fastq.gz"), provide the proper files end with --fastq_end option
 
   Otherwise, if you are uploading a different type of file, like bam files or fasta files, you can name them whatever you like but they should have the prefix at the end, e.g. .bam or .fasta.  Use the -F flag to do so, e.g. -F bam.
 
@@ -173,9 +175,12 @@ You should familarise yourself with the other options before you begin running t
                           is needed to generate the study.xml file. The file
                           should be in the following format: full title of the
                           project abstract
-    --center_name CENTER_NAME, -c CENTER_NAME
-                          Please provide the center name
-    --refname REFNAME, -r REFNAME
+    -c "Public Health England", --center_name "Public Health England"
+                          Please provide the center name. The center name is a
+                          controlled vocabulary identifying the sequencing
+                          center, core facility, consortium, or laboratory
+                          responsible for the study.
+    -r PHE_20180125, --refname PHE_20180125
                           Please provide the unique name for the whole
                           submission. This name must not have been used before
                           in any other submission to ENA.
@@ -213,6 +218,13 @@ You should familarise yourself with the other options before you begin running t
     --out_dir OUT_DIR, -o OUT_DIR
                           please provide the path to the output directory which
                           will include all the xml files.
+    --fastq_ends .R1.fastq.gz .R2.fastq.gz
+                          By default, ena_submission.py searches for pair-end
+                          fastq files ending with ".R1.fastq.gz" and
+                          ".R2.fastq.gz". If your fastq files end differently,
+                          you can provide two strings containing the end of
+                          fastq files names (for example, "_1.fastq.gz" and
+                          "_2.fastq.gz")
 
 
 ## Contact

--- a/ena_submission.py
+++ b/ena_submission.py
@@ -1,379 +1,415 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
-import os, os.path, sys, subprocess, glob, inspect
-
-module_folder_paths = ["modules"]
-
-for module_folder_path in module_folder_paths:
-	module_folder = os.path.realpath(os.path.abspath(os.path.join(os.path.split(inspect.getfile( inspect.currentframe() ))[0],module_folder_path)))
-	if module_folder not in sys.path:
-		sys.path.insert(1, module_folder)
-
-import populate_data_to_ENA
+import os, sys, inspect
 import argparse
-from argparse import RawTextHelpFormatter
 import textwrap
 
+module_folder_paths = ["modules"]
+for module_folder_path in module_folder_paths:
+    module_folder = os.path.realpath(os.path.abspath(os.path.join(os.path.split(inspect.getfile( inspect.currentframe() ))[0],module_folder_path)))
+    if module_folder not in sys.path:
+        sys.path.insert(1, module_folder)
+
+import populate_data_to_ENA
+
+
 class MultilineFormatter(argparse.HelpFormatter):
-	# class to provide new lines when comments below are displayed in git.
+    # class to provide new lines when comments below are displayed in git.
     def _fill_text(self, text, width, indent):
-		text = self._whitespace_matcher.sub(' ', text).strip()
-		paragraphs = text.split('|n ')
-		multiline_text = ''
-		for paragraph in paragraphs:
-		    formatted_paragraph = textwrap.fill(paragraph, width=500, initial_indent=indent, subsequent_indent=indent) + '\n\n'
-		    multiline_text = multiline_text + formatted_paragraph
-		return multiline_text
+        text = self._whitespace_matcher.sub(' ', text).strip()
+        paragraphs = text.split('|n ')
+        multiline_text = ''
+        for paragraph in paragraphs:
+            formatted_paragraph = textwrap.fill(paragraph, width=500, initial_indent=indent, subsequent_indent=indent) + '\n\n'
+            multiline_text = multiline_text + formatted_paragraph
+        return multiline_text
 
 
 def set_up_argparse():
-	parser = argparse.ArgumentParser(description="""
+    parser = argparse.ArgumentParser(description="""
 
-	**This tool in a single step will create the necessary xml files and uploads all your files to the ENA repository.**|n
-	Description of the Process|n
-	--------------------------|n
-	In order to submit your files as a batch to ENA, you need to create some files that have information about your samples which then you can use to upload to ENA.  It can be a tedious task.  This script would make this possible in one step.  This is how it works (provided that you have provided the necessary files, see 'Required files' below):|n
+    **This tool in a single step will create the necessary xml files and uploads all your files to the ENA repository.**|n
+    Description of the Process|n
+    --------------------------|n
+    In order to submit your files as a batch to ENA, you need to create some files that have information about your samples which then you can use to upload to ENA.  It can be a tedious task.  This script would make this possible in one step.  This is how it works (provided that you have provided the necessary files, see 'Required files' below):|n
 
-	1- Creates a checksum file of all your files needed for submission.|n
-	2- Uploads the files to the ENA server using FTP.  It will use the authentications you have provided it.|n
-	3- Provided the data that you have provided is correct, the script will create five xml files: sample.xml, experiment.xml, run.xml, study.xml and submission.xml.|n
-	4- If all the .xml files have been successfully created, the script will run a test curl command that will upload all the .xml files to the ENA server and returns a receipt.xml file.  If this process failes, you will be notified and you must correct the error and re-submit using the -curl option.  The script will run a test command to test if its sucessful. You must then run the production curl command to upload your data to production.|n
-
-
-	Dependencies|n
-	------------|n
-	
-
-	None.|n
+    1- Creates a checksum file of all your files needed for submission.|n
+    2- Uploads the files to the ENA server using FTP.  It will use the authentications you have provided it.|n
+    3- Provided the data that you have provided is correct, the script will create five xml files: sample.xml, experiment.xml, run.xml, study.xml and submission.xml.|n
+    4- If all the .xml files have been successfully created, the script will run a test curl command that will upload all the .xml files to the ENA server and returns a receipt.xml file.  If this process failes, you will be notified and you must correct the error and re-submit using the -curl option.  The script will run a test command to test if its sucessful. You must then run the production curl command to upload your data to production.|n
 
 
-	Required files|n
-	--------------|n
+    Dependencies|n
+    ------------|n
+    
+
+    None.|n
+
+
+    Required files|n
+    --------------|n
 Merge the remote changes before pushing again
-	To upload your files to ENA, you will need the following:|n
+    To upload your files to ENA, you will need the following:|n
 
-	1- A directory which contains all your files (fwd and rev).  If you are uploading fastq files, the files must be in the following format:|n
+    1- A directory which contains all your files (fwd and rev).  If you are uploading fastq files, the files must be in the following format:|n
 
-	SAMPLE_NAME.R1.fastq.gz|n
-	SAMPLE_NAME.R2.fastq.gz|n
+    SAMPLE_NAME.R1.fastq.gz|n
+    SAMPLE_NAME.R2.fastq.gz|n
 
-	E.g. |n
+    E.g. |n
 
-	MN127.R1.fastq.gz|n
-	MN127.R2.fastq.gz|n
+    MN127.R1.fastq.gz|n
+    MN127.R2.fastq.gz|n
+    
+    If your files end differently (from ".R1.fastq.gz" and ".R2.fastq.gz"), provide the proper files end with --fastq_end option
 
-	Otherwise, if you are uploading a different type of file, like bam files or fasta files, you can name them whatever you like but they should have the suffix at the end, e.g. .bam or .fasta|n
+    Otherwise, if you are uploading a different type of file, like bam files or fasta files, you can name them whatever you like but they should have the suffix at the end, e.g. .bam or .fasta|n
 
-	2- A csv (comma separated values) file that contains all the information for each of your samples.  The text file should contain four required columns.  You may add as many coloumns of data as you wish after the fourth required coloumn.  The columns are separated by commas.  e.g. (note the headings are required and the order must be respected):|n
+    2- A tab (tabular separated values) file that contains all the information for each of your samples.  The text file should contain four required columns.  You may add as many coloumns of data as you wish after the fourth required coloumn.  The columns are separated by tabs.  e.g. (note the headings are required and the order must be respected):|n
 
-	SAMPLE,TAXON_ID,SCIENTIFIC_NAME,DESCRIPTION|n
+    SAMPLE,TAXON_ID,SCIENTIFIC_NAME,DESCRIPTION|n
 
-	data....|n
+    data....|n
 
-	See a template file in the examples dir.|n
+    See a template file in the examples dir.|n
 
-	3- A text file that contains the title for your project and an abstract explaining the project.  The two coloumns must be separated by TABS. There are no headings needed here. e.g.|n
+    3- A text file that contains the title for your project and an abstract explaining the project.  The two coloumns must be separated by TABS. There are no headings needed here. e.g.|n
 
-	Bioinformatics for biologists \t Bioinformatics is great for biologists.....etc|n
+    Bioinformatics for biologists \t Bioinformatics is great for biologists.....etc|n
 
-	4- An ENA ftp username and password.  If you do not have one, you need to contact ENA at: datasubs@ebi.ac.uk.|n
+    4- An ENA ftp username and password.  If you do not have one, you need to contact ENA at: datasubs@ebi.ac.uk.|n
 
-	NOTE!! If you are uploading files other than fastq files, you must use the -F flag and add the suffix, e.g. -F bam.|n
+    NOTE!! If you are uploading files other than fastq files, you must use the -F flag and add the suffix, e.g. -F bam.|n
 
-	Before you run the script....|n
+    Before you run the script....|n
 
-	-------------------|n
+    -------------------|n
 
-	Before you run the script, make sure you have the following ready as you cannot proceed without it:|n
+    Before you run the script, make sure you have the following ready as you cannot proceed without it:|n
 
-	      -i : dir to your files|n
-	      -r : a reference name for your project|n
-	      -f : the path to the data file (see point 2 above)|n
-	      -a : the path to the title and abstract text file|n
-	      -o : the path to the output directory|n
-	      -user : ENA username|n
-	      -pass : ENA password|n
+          -i : dir to your files|n
+          -r : a reference name for your project|n
+          -f : the path to the data file (see point 2 above)|n
+          -a : the path to the title and abstract text file|n
+          -o : the path to the output directory|n
+          -user : ENA username|n
+          -pass : ENA password|n
 
-	You may like to familarise yourself with the other options you can use before running the script.|n
-
-
-	Examples of commands|n
-	--------------------|n
-
-	So, what do you like to do? |n
-
-	If you like to run a single command that does EVERYTHING, i.e. creates checksums, uploads your files to ftp, creates the xml files, uploads the xml files and run the curl command, then use the -d option, e.g. |n
+    You may like to familarise yourself with the other options you can use before running the script.|n
 
 
-	E.g. for fastq submission (otherwise use -F suffix)|n
+    Examples of commands|n
+    --------------------|n
 
-	    python ena_submission.py -d -i /PATH/TO/SAMPLES_FILES_DIR -r phe_mycoplasma -f /PATH/TO/DATA_FILE.txt -o /PATH/TO/OUTPUT_DIR -a /PATH/TO/TITLE_ABSTRACT_FILE.txt -c CENTRE_NAME -user Webin-YYYYY -pass XXXXX|n
+    So, what do you like to do? |n
 
-	
-	Or you may wish to run each step individually. The following are examples of how to run each step individually:|n
-	----|n
+    If you like to run a single command that does EVERYTHING, i.e. creates checksums, uploads your files to ftp, creates the xml files, uploads the xml files and run the curl command, then use the -d option, e.g. |n
 
-	To just create the checksums file:|n
 
-	--create_checksums_file : only create the checksums file for my fastqs. e.g.|n
-	    python ena_submission.py -cs -i /SOME/PATH/fastqs -r test3|n
+    E.g. for fastq submission (otherwise use -F suffix)|n
 
-	----|n
+        python ena_submission.py -d -i /PATH/TO/SAMPLES_FILES_DIR -r phe_mycoplasma -f /PATH/TO/DATA_FILE.txt -o /PATH/TO/OUTPUT_DIR -a /PATH/TO/TITLE_ABSTRACT_FILE.txt -c CENTRE_NAME -user Webin-YYYYY -pass XXXXX|n
 
-	To just upload your data to the ENA server:|n
+    
+    Or you may wish to run each step individually. The following are examples of how to run each step individually:|n
+    ----|n
 
-	--upload_data_to_ena_ftp_server : only upload the data to ENA. e.g.|n
-	    python ena_submission.py -ftp -i /SOME/PATH/fastqs -r phe_mycoplasma -user Webin-40432 -pass XXXXX|n
+    To just create the checksums file:|n
 
-	----|n
+    --create_checksums_file : only create the checksums file for my fastqs. e.g.|n
+        python ena_submission.py -cs -i /SOME/PATH/fastqs -r test3|n
 
-	To just create sample.xml file:|n
+    ----|n
 
-	  -x sample : use the word 'sample' (same goes for the rest) to create sample.xml only. e.g.|n
+    To just upload your data to the ENA server:|n
 
-	    python ena_submission.py -x sample -i /SOME/PATH/fastqs -r phe_mycoplasma -f /SOME/PATH/data_file_for_ena_submission.txt -c CENTRE_NAME -o /SOME/PATH/ena_submission|n
-	----|n
+    --upload_data_to_ena_ftp_server : only upload the data to ENA. e.g.|n
+        python ena_submission.py -ftp -i /SOME/PATH/fastqs -r phe_mycoplasma -user Webin-40432 -pass XXXXX|n
 
-	To create all xml files:  file:|n
+    ----|n
 
-	  -x all : creates sample.xml, experiment.xml, run.xml, study.xml and submission.xml. Note that you need to run the -curl command to submit the data into the ENA test server. e.g.|n
+    To just create sample.xml file:|n
 
-	    python ena_submission.py -x all -i /SOME/PATH/fastqs -r phe_mycoplasma -f /SOME/PATH/data_file_for_ena_submission.txt -c CENTRE_NAME -o /SOME/PATH/ena_submission|n
-	----|n
-	To just create experiment.xml file:|n
+      -x sample : use the word 'sample' (same goes for the rest) to create sample.xml only. e.g.|n
 
-	  -x experiment : to create experiment.xml only. e.g.|n
+        python ena_submission.py -x sample -i /SOME/PATH/fastqs -r phe_mycoplasma -f /SOME/PATH/data_file_for_ena_submission.txt -c CENTRE_NAME -o /SOME/PATH/ena_submission|n
+    ----|n
 
-	    python ena_submission.py -x experiment -i /SOME/PATH/fastqs -r phe_mycoplasma -f /SOME/PATH/data_file_for_ena_submission.txt -c CENTRE_NAME -o /SOME/PATH/ena_submission  |n
-	----|n
+    To create all xml files:  file:|n
 
-	To just create run.xml file:|n
+      -x all : creates sample.xml, experiment.xml, run.xml, study.xml and submission.xml. Note that you need to run the -curl command to submit the data into the ENA test server. e.g.|n
 
-	  -x run : to create run.xml only. e.g.|n
+        python ena_submission.py -x all -i /SOME/PATH/fastqs -r phe_mycoplasma -f /SOME/PATH/data_file_for_ena_submission.txt -c CENTRE_NAME -o /SOME/PATH/ena_submission|n
+    ----|n
+    To just create experiment.xml file:|n
 
-	    python ena_submission.py -x run -i /SOME/PATH/fastqs -r phe_mycoplasma -c CENTRE_NAME -o /SOME/PATH/ena_submission|n
-	----|n
+      -x experiment : to create experiment.xml only. e.g.|n
 
-	To just create study.xml file:|n
-	  -x study : to create study.xml only. e.g.|n
+        python ena_submission.py -x experiment -i /SOME/PATH/fastqs -r phe_mycoplasma -f /SOME/PATH/data_file_for_ena_submission.txt -c CENTRE_NAME -o /SOME/PATH/ena_submission  |n
+    ----|n
 
-	    python ena_submission.py -x study -a /SOME/PATH/title_and_abstract_for_ena.txt -r phe_mycoplasma -i /SOME/PATH/fastqs -c CENTRE_NAME -o /SOME/PATH/ena_submission|n
+    To just create run.xml file:|n
 
-	----|n
+      -x run : to create run.xml only. e.g.|n
 
-	To just create submission.xml file:|n
+        python ena_submission.py -x run -i /SOME/PATH/fastqs -r phe_mycoplasma -c CENTRE_NAME -o /SOME/PATH/ena_submission|n
+    ----|n
 
-	  -x submission : to create submission.xml only. e.g.|n
+    To just create study.xml file:|n
+      -x study : to create study.xml only. e.g.|n
 
-	    python ena_submission.py -x submission -i /SOME/PATH/fastqs -o /SOME/PATH/ena_submission -r phe_mycoplasma -c CENTRE_NAME |n
+        python ena_submission.py -x study -a /SOME/PATH/title_and_abstract_for_ena.txt -r phe_mycoplasma -i /SOME/PATH/fastqs -c CENTRE_NAME -o /SOME/PATH/ena_submission|n
 
-	  NOTE: Here you may hold your data from release publicly if you use -ho option and specify the date.|n
+    ----|n
 
-	----|n
+    To just create submission.xml file:|n
 
-	To just run the curl command:|n
+      -x submission : to create submission.xml only. e.g.|n
 
-	  -curl : just run curl command.  Note: you must have uploaded the data and created all the xml files to run the curl command. e.g.|n
+        python ena_submission.py -x submission -i /SOME/PATH/fastqs -o /SOME/PATH/ena_submission -r phe_mycoplasma -c CENTRE_NAME |n
 
-	    python ena_submission.py -curl -user Webin-40432 -pass XXXX -o /SOME/PATH/ena_submission|n
+      NOTE: Here you may hold your data from release publicly if you use -ho option and specify the date.|n
 
-	--------|n
+    ----|n
 
-	Contact|n
-	-------|n
+    To just run the curl command:|n
 
-	Ali Al-Shahib|n
-	ali.al-shahib@phe.gov.uk|n""", formatter_class=MultilineFormatter)
+      -curl : just run curl command.  Note: you must have uploaded the data and created all the xml files to run the curl command. e.g.|n
 
-	# parser = argparse.ArgumentParser(epilog="Good luck! If your jobs breaks, don't blame me :-)", add_help=True)
-	parser.add_argument('--do_everything', '-d', help='This option would run everything in one step, i.e: 1) Create checkums, 2) Uploads files to ENA ftp server, 3) Creats all the XML files, 4) Submits XML files to ENA (test only)',action='store_true')
-	parser.add_argument('--generate_xml_file_for', '-x', help='please provide the name for the xml you like to generate, one of the following:all,experiment,run,sample,study,submission')
-	parser.add_argument('--dir_of_input_data', '-i', help='please provide the path for the files you like to upload to ENA. NOTE: the fastq files must be in the following format: *.R1.fastq.gz and *.R2.fastq.gz.')
-	parser.add_argument('--data_file', '-f', help='data_file, file : this text file must have at least four columns seperated by TABS in the following order and with the following headings:  Column 1: SAMPLE, Column 2: TAXON_ID, Column 3: SCIENTIFIC_NAME, Column 4: DESCRIPTION.  If you like to add further data then add it after the DESCRIPTION column.')
-	parser.add_argument('--ftp_user_name', '-user', help='please provide the ftp user name')
-	parser.add_argument('--ftp_password', '-pass', help='please provide the ftp password')
-	parser.add_argument('--title_and_abstract_file', '-a', help='please provide the title and abstract text file.  This is needed to generate the study.xml file.  The file should be in the following format: full title of the project\tabstract')
-	parser.add_argument('--center_name', '-c', help='Please provide the center name')
-	parser.add_argument('--refname', '-r', help='Please provide the unique name for the whole submission. This name must not have been used before in any other submission to ENA.')
-	parser.add_argument('--library_strategy', '-s', help='please provide the library strategy used. default = WGS', default='WGS')#
-	parser.add_argument('--library_source', '-u', help='please provide the library source used. default = GENOMIC', default='GENOMIC')
-	parser.add_argument('--library_selection', '-e', help='please provide the library selection used. default = RANDOM', default='RANDOM')
-	parser.add_argument('--read_length', '-l', help='Please provide the read length. default = 100', default='100')
-	parser.add_argument('--read_sdev', '-sdev', help='Please provide the read stdv. default = 0.0', default='0.0')
-	parser.add_argument('--instrument_model', '-m', help='please provide the name of the instrument model used. default = Illumina HiSeq 2500', default='Illumina HiSeq 2500')
-	parser.add_argument('--filetype', '-F', help='Please provide the file type, default=fastq', default='fastq')
-	parser.add_argument('--hold_date', '-ho', help='This option will hold the data privately until a specified date.  Please provide the specified date using the following format: YYYY-MM-DD')
-	parser.add_argument('--release', '-R', help='This option will release the data immediatley to the public domain. Cannot be used with --hold_date. default = False', default=False, action='store_true')
-	parser.add_argument('--curl_command', '-curl', help='Run curl command to upload everything to ENA',action='store_true')
-	parser.add_argument('--create_checksums_file', '-cs', help='Create a checksum file',action='store_true')
-	parser.add_argument('--upload_data_to_ena_ftp_server', '-ftp', help='Upload data into the ftp server',action='store_true')
-	parser.add_argument('--out_dir', '-o', help='please provide the path to the output directory which will include all the xml files.')
-	opts = parser.parse_args()
-	
-	return opts
+        python ena_submission.py -curl -user Webin-40432 -pass XXXX -o /SOME/PATH/ena_submission|n
+
+    --------|n
+
+    Contact|n
+    -------|n
+
+    Ali Al-Shahib|n
+    ali.al-shahib@phe.gov.uk|n""", formatter_class=MultilineFormatter)
+
+    # TODO: improve argparse
+    # parser = argparse.ArgumentParser(epilog="Good luck! If your jobs breaks, don't blame me :-)", add_help=True)
+    parser.add_argument('--do_everything', '-d', help='This option would run everything in one step, i.e: 1) Create checkums, 2) Uploads files to ENA ftp server, 3) Creats all the XML files, 4) Submits XML files to ENA (test only)',action='store_true')
+    parser.add_argument('--generate_xml_file_for', '-x', help='please provide the name for the xml you like to generate, one of the following:all,experiment,run,sample,study,submission')
+    parser.add_argument('--dir_of_input_data', '-i', help='please provide the path for the files you like to upload to ENA. NOTE: the fastq files must be in the following format: *.R1.fastq.gz and *.R2.fastq.gz.')
+    parser.add_argument('--data_file', '-f', help='data_file, file : this text file must have at least four columns seperated by TABS in the following order and with the following headings:  Column 1: SAMPLE, Column 2: TAXON_ID, Column 3: SCIENTIFIC_NAME, Column 4: DESCRIPTION.  If you like to add further data then add it after the DESCRIPTION column.')
+    parser.add_argument('--ftp_user_name', '-user', help='please provide the ftp user name')
+    parser.add_argument('--ftp_password', '-pass', help='please provide the ftp password')
+    parser.add_argument('--title_and_abstract_file', '-a', help='please provide the title and abstract text file.  This is needed to generate the study.xml file.  The file should be in the following format: full title of the project\tabstract')
+    parser.add_argument('-c', '--center_name',
+                        type=str,
+                        metavar='"Public Health England"',
+                        help='Please provide the center name. The center name is a controlled vocabulary identifying'
+                             ' the sequencing center, core facility, consortium, or laboratory responsible for the'
+                             ' study.',
+                        required=True)
+    parser.add_argument('-r', '--refname',
+                        type=str,
+                        nargs=1,
+                        metavar='PHE_20180125',
+                        help='Please provide the unique name for the whole submission. This name must not have been'
+                             ' used before in any other submission to ENA.')
+    parser.add_argument('--library_strategy', '-s', help='please provide the library strategy used. default = WGS', default='WGS')#
+    parser.add_argument('--library_source', '-u', help='please provide the library source used. default = GENOMIC', default='GENOMIC')
+    parser.add_argument('--library_selection', '-e', help='please provide the library selection used. default = RANDOM', default='RANDOM')
+    parser.add_argument('--read_length', '-l', help='Please provide the read length. default = 100', default='100')
+    parser.add_argument('--read_sdev', '-sdev', help='Please provide the read stdv. default = 0.0', default='0.0')
+    parser.add_argument('--instrument_model', '-m', help='please provide the name of the instrument model used. default = Illumina HiSeq 2500', default='Illumina HiSeq 2500')
+    parser.add_argument('--filetype', '-F', help='Please provide the file type, default=fastq', default='fastq')
+    parser.add_argument('--hold_date', '-ho', help='This option will hold the data privately until a specified date.  Please provide the specified date using the following format: YYYY-MM-DD')
+    parser.add_argument('--release', '-R', help='This option will release the data immediatley to the public domain. Cannot be used with --hold_date. default = False', default=False, action='store_true')
+    parser.add_argument('--curl_command', '-curl', help='Run curl command to upload everything to ENA',action='store_true')
+    parser.add_argument('--create_checksums_file', '-cs', help='Create a checksum file',action='store_true')
+    parser.add_argument('--upload_data_to_ena_ftp_server', '-ftp', help='Upload data into the ftp server',action='store_true')
+    parser.add_argument('--out_dir', '-o', help='please provide the path to the output directory which will include all the xml files.')
+    parser.add_argument('--fastq_ends',
+                        nargs=2,
+                        type=str,
+                        metavar=('.R1.fastq.gz', '.R2.fastq.gz'),
+                        help='By default, ena_submission.py searches for pair-end fastq files ending with'
+                             ' ".R1.fastq.gz" and ".R2.fastq.gz". If your fastq files end differently, you can provide'
+                             ' two strings containing the end of fastq files names (for example, "_1.fastq.gz" and'
+                             ' "_2.fastq.gz")',
+                        required=False,
+                        default=['.R1.fastq.gz', '.R2.fastq.gz'])
+    opts = parser.parse_args()
+
+    # Check --refname only contains one word
+    opts.refname = opts.refname[0]
+    if not isinstance(opts.refname, str):
+        raise argparse.ArgumentTypeError('{argument_name} must be a string'.format(argument_name='--refname'))
+    else:
+        if len(opts.refname.split(' ')) > 1:
+            raise argparse.ArgumentTypeError('{argument_name} requires only one word'.format(argument_name='--refname'))
+
+    opts.fastq_ends = tuple(opts.fastq_ends)
+    return opts
 
 def make_dir_if_not_made(name):
-	if not os.path.exists(name):
-		    os.makedirs(name)
+    if not os.path.exists(name):
+            os.makedirs(name)
 
 def check_if_flag_is_provided(flag,name,option):
-	if flag is None:
-		print "Checking if", name, "is provided...No!"
-		print "You have not provided the", name,"!", "use the",option,"option to provide the", name
-		sys.exit(1)
-	else:
-		print "Checking if", name, "is provided...Yes"
+    if flag is None:
+        print "Checking if", name, "is provided...No!"
+        print "You have not provided the", name,"!", "use the",option,"option to provide the", name
+        sys.exit(1)
+    else:
+        print "Checking if", name, "is provided...Yes"
 
 def main(opts):
 
-	if opts.create_checksums_file:
-		check_if_flag_is_provided(opts.refname,"refname","-r")
-		check_if_flag_is_provided(opts.dir_of_input_data,"dir_of_input_data","-i")
-		populate_data_to_ENA.create_checksums_file(opts.dir_of_input_data,opts.refname,opts.filetype)
-		sys.exit()
+    if opts.create_checksums_file:
+        check_if_flag_is_provided(opts.refname,"refname","-r")
+        check_if_flag_is_provided(opts.dir_of_input_data,"dir_of_input_data","-i")
+        populate_data_to_ENA.create_checksums_file(opts.dir_of_input_data, opts.refname, opts.filetype, opts.fastq_ends)
+        sys.exit()
 
-	elif opts.upload_data_to_ena_ftp_server:
-		check_if_flag_is_provided(opts.dir_of_input_data,"dir_of_input_data","-i")
-		check_if_flag_is_provided(opts.refname,"refname","-r")
-		check_if_flag_is_provided(opts.ftp_user_name, "ftp_user_name", "-user")
-		check_if_flag_is_provided(opts.ftp_password, "ftp_password", "pass")
-		populate_data_to_ENA.upload_data_to_ena_ftp_server(opts.dir_of_input_data,opts.refname,opts.ftp_user_name,opts.ftp_password,opts.filetype)
-		sys.exit()
+    elif opts.upload_data_to_ena_ftp_server:
+        check_if_flag_is_provided(opts.dir_of_input_data,"dir_of_input_data","-i")
+        check_if_flag_is_provided(opts.refname,"refname","-r")
+        check_if_flag_is_provided(opts.ftp_user_name, "ftp_user_name", "-user")
+        check_if_flag_is_provided(opts.ftp_password, "ftp_password", "pass")
+        populate_data_to_ENA.upload_data_to_ena_ftp_server(opts.dir_of_input_data,opts.refname,opts.ftp_user_name,opts.ftp_password,opts.filetype, opts.fastq_ends)
+        sys.exit()
 
-	elif opts.curl_command:
-		check_if_flag_is_provided(opts.ftp_user_name, "ftp_user_name", "-user")
-		check_if_flag_is_provided(opts.ftp_password, "ftp_password", "pass")
-		check_if_flag_is_provided(opts.out_dir,"out_dir","-o")
-		populate_data_to_ENA.run_curl_command(opts.ftp_user_name,opts.ftp_password,opts.out_dir)
-		sys.exit()
+    elif opts.curl_command:
+        check_if_flag_is_provided(opts.ftp_user_name, "ftp_user_name", "-user")
+        check_if_flag_is_provided(opts.ftp_password, "ftp_password", "pass")
+        check_if_flag_is_provided(opts.out_dir,"out_dir","-o")
+        populate_data_to_ENA.run_curl_command(opts.ftp_user_name,opts.ftp_password,opts.out_dir)
+        sys.exit()
 
-	elif opts.do_everything:
-		print "\nYou would like me to upload your files, generate all the xml files needed to submit your data to ENA, and upload the xml files to ENA.\nLet me check if you have provided all the necessary information....\n"
-		# check if output file exists, otherwise create it...
-		
-		check_if_flag_is_provided(opts.ftp_user_name, "ftp_user_name", "-user")
-		check_if_flag_is_provided(opts.ftp_password, "ftp_password", "pass")
-		check_if_flag_is_provided(opts.dir_of_input_data,"dir_of_input_data","-i")
-		check_if_flag_is_provided(opts.center_name,"center_name","-c")
-		check_if_flag_is_provided(opts.refname,"refname","-r")
-		check_if_flag_is_provided(opts.data_file,"data_file","-f")
-		check_if_flag_is_provided(opts.title_and_abstract_file,"title_and_abstract_file","-a")
-		check_if_flag_is_provided(opts.out_dir,"out_dir","-o")
-		make_dir_if_not_made(opts.out_dir)
+    elif opts.do_everything:
+        print "\nYou would like me to upload your files, generate all the xml files needed to submit your data to ENA, and upload the xml files to ENA.\nLet me check if you have provided all the necessary information....\n"
+        # check if output file exists, otherwise create it...
 
-		populate_data_to_ENA.check_data_file(opts.data_file)
-		populate_data_to_ENA.check_abstract_file(opts.title_and_abstract_file)
-		populate_data_to_ENA.create_checksums_file(opts.dir_of_input_data,opts.refname,opts.filetype)
-		populate_data_to_ENA.upload_data_to_ena_ftp_server(opts.dir_of_input_data,opts.refname,opts.ftp_user_name,opts.ftp_password,opts.filetype)
-		populate_data_to_ENA.sample_xml(opts.dir_of_input_data,opts.refname,opts.data_file,opts.center_name,opts.out_dir)
-		populate_data_to_ENA.experiment_xml(opts.dir_of_input_data,opts.data_file,opts.refname,opts.center_name,opts.library_strategy,opts.library_source,opts.library_selection,opts.read_length,opts.read_sdev,opts.instrument_model,opts.out_dir)
-		populate_data_to_ENA.run_xml(opts.dir_of_input_data,opts.refname,opts.center_name,opts.filetype,opts.out_dir)
-		populate_data_to_ENA.study_xml(opts.title_and_abstract_file,opts.center_name,opts.refname,opts.out_dir)
-		populate_data_to_ENA.submission_xml(opts.refname,opts.center_name,opts.out_dir,opts.hold_date)
+        check_if_flag_is_provided(opts.ftp_user_name, "ftp_user_name", "-user")
+        check_if_flag_is_provided(opts.ftp_password, "ftp_password", "pass")
+        check_if_flag_is_provided(opts.dir_of_input_data,"dir_of_input_data","-i")
+        check_if_flag_is_provided(opts.center_name,"center_name","-c")
+        check_if_flag_is_provided(opts.refname,"refname","-r")
+        check_if_flag_is_provided(opts.data_file,"data_file","-f")
+        check_if_flag_is_provided(opts.title_and_abstract_file,"title_and_abstract_file","-a")
+        check_if_flag_is_provided(opts.out_dir,"out_dir","-o")
+        make_dir_if_not_made(opts.out_dir)
 
-		print "\nAll your xml files have been generated successfully in", opts.out_dir, "\n"
+        populate_data_to_ENA.check_data_file(opts.data_file)
+        populate_data_to_ENA.check_abstract_file(opts.title_and_abstract_file)
+        populate_data_to_ENA.create_checksums_file(opts.dir_of_input_data,opts.refname,opts.filetype, opts.fastq_ends)
+        populate_data_to_ENA.upload_data_to_ena_ftp_server(opts.dir_of_input_data,opts.refname,opts.ftp_user_name,opts.ftp_password,opts.filetype, opts.fastq_ends)
+        populate_data_to_ENA.sample_xml(opts.dir_of_input_data,opts.refname,opts.data_file,opts.center_name,opts.out_dir, opts.fastq_ends)
+        populate_data_to_ENA.experiment_xml(opts.dir_of_input_data,opts.data_file,opts.refname,opts.center_name,opts.library_strategy,opts.library_source,opts.library_selection,opts.read_length,opts.read_sdev,opts.instrument_model, opts.fastq_ends, opts.out_dir)
+        populate_data_to_ENA.run_xml(opts.dir_of_input_data,opts.refname,opts.center_name,opts.filetype,opts.out_dir, opts.fastq_ends)
+        populate_data_to_ENA.study_xml(opts.title_and_abstract_file,opts.center_name,opts.refname,opts.out_dir)
+        populate_data_to_ENA.submission_xml(opts.refname,opts.center_name,opts.out_dir,opts.hold_date)
 
-		print "\nNow running curl command..."
+        print "\nAll your xml files have been generated successfully in", opts.out_dir, "\n"
 
-		populate_data_to_ENA.run_curl_command(opts.ftp_user_name,opts.ftp_password,opts.out_dir)
+        print "\nNow running curl command..."
 
-		print "All done...Your files have been submitted to the ENA test server. please check if all the files have been uploaded to ENA."
-		# print "All done...please check if all the files have been uploaded to ENA."
+        populate_data_to_ENA.run_curl_command(opts.ftp_user_name,opts.ftp_password,opts.out_dir)
+
+        print "All done...Your files have been submitted to the ENA test server. please check if all the files have been uploaded to ENA."
+        # print "All done...please check if all the files have been uploaded to ENA."
 
 
-	elif opts.generate_xml_file_for == "sample":
+    elif opts.generate_xml_file_for == "sample":
 
-		print "\nYou would like me to generate the", opts.generate_xml_file_for,".xml file needed to submit your data to ENA....\nLet me check if you have provided all the necessary information....\n"
+        print "\nYou would like me to generate the", opts.generate_xml_file_for,".xml file needed to submit your data to ENA....\nLet me check if you have provided all the necessary information....\n"
 
-		check_if_flag_is_provided(opts.dir_of_input_data,"dir_of_input_data","-i")
-		check_if_flag_is_provided(opts.refname,"refname","-r")
-		check_if_flag_is_provided(opts.center_name,"center_name","-c")
-		check_if_flag_is_provided(opts.data_file,"data_file","-f")
-		check_if_flag_is_provided(opts.out_dir,"out_dir","-o")	
-		make_dir_if_not_made(opts.out_dir)
+        check_if_flag_is_provided(opts.dir_of_input_data,"dir_of_input_data","-i")
+        check_if_flag_is_provided(opts.refname,"refname","-r")
+        check_if_flag_is_provided(opts.center_name,"center_name","-c")
+        check_if_flag_is_provided(opts.data_file,"data_file","-f")
+        check_if_flag_is_provided(opts.out_dir,"out_dir","-o")
+        make_dir_if_not_made(opts.out_dir)
 
-		populate_data_to_ENA.check_data_file(opts.data_file)
-		populate_data_to_ENA.sample_xml(opts.dir_of_input_data,opts.refname,opts.data_file,opts.center_name,opts.out_dir)
+        populate_data_to_ENA.check_data_file(opts.data_file)
+        populate_data_to_ENA.sample_xml(opts.dir_of_input_data,opts.refname,opts.data_file,opts.center_name,opts.out_dir, opts.fastq_ends)
 
-		print "\nYour", opts.generate_xml_file_for,".xml file have been generated successfully in", opts.out_dir
+        print "\nYour", opts.generate_xml_file_for,".xml file have been generated successfully in", opts.out_dir
 
-	elif opts.generate_xml_file_for == "experiment":
+    elif opts.generate_xml_file_for == "experiment":
 
-		print "\nYou would like me to generate the", opts.generate_xml_file_for, ".xml file needed to submit your data to ENA....\nLet me check if you have provided all the necessary information....\n"
+        print "\nYou would like me to generate the", opts.generate_xml_file_for, ".xml file needed to submit your data to ENA....\nLet me check if you have provided all the necessary information....\n"
 
-		check_if_flag_is_provided(opts.dir_of_input_data,"dir_of_input_data","-i")
-		check_if_flag_is_provided(opts.refname,"refname","-r")
-		check_if_flag_is_provided(opts.center_name,"center_name","-c")
-		check_if_flag_is_provided(opts.data_file,"data_file","-f")
-		check_if_flag_is_provided(opts.out_dir,"out_dir","-o")
-		make_dir_if_not_made(opts.out_dir)
+        check_if_flag_is_provided(opts.dir_of_input_data,"dir_of_input_data","-i")
+        check_if_flag_is_provided(opts.refname,"refname","-r")
+        check_if_flag_is_provided(opts.center_name,"center_name","-c")
+        check_if_flag_is_provided(opts.data_file,"data_file","-f")
+        check_if_flag_is_provided(opts.out_dir,"out_dir","-o")
+        make_dir_if_not_made(opts.out_dir)
 
-		populate_data_to_ENA.check_data_file(opts.data_file)
-		populate_data_to_ENA.experiment_xml(opts.dir_of_input_data,opts.data_file,opts.refname,opts.center_name,opts.library_strategy,opts.library_source,opts.library_selection,opts.read_length,opts.read_sdev,opts.instrument_model,opts.out_dir)
+        populate_data_to_ENA.check_data_file(opts.data_file)
+        populate_data_to_ENA.experiment_xml(opts.dir_of_input_data,opts.data_file,opts.refname,opts.center_name,opts.library_strategy,opts.library_source,opts.library_selection,opts.read_length,opts.read_sdev,opts.instrument_model, opts.fastq_ends, opts.out_dir)
 
-		print "\nYour", opts.generate_xml_file_for,".xml file have been generated successfully in", opts.out_dir
+        print "\nYour", opts.generate_xml_file_for,".xml file have been generated successfully in", opts.out_dir
 
-	elif opts.generate_xml_file_for == "run":
+    elif opts.generate_xml_file_for == "run":
 
-		print "\nYou would like me to generate the", opts.generate_xml_file_for, ".xml file needed to submit your data to ENA....\nLet me check if you have provided all the necessary information....\n"
+        print "\nYou would like me to generate the", opts.generate_xml_file_for, ".xml file needed to submit your data to ENA....\nLet me check if you have provided all the necessary information....\n"
 
-		check_if_flag_is_provided(opts.dir_of_input_data,"dir_of_input_data","-i")
-		check_if_flag_is_provided(opts.refname,"refname","-r")
-		check_if_flag_is_provided(opts.center_name,"center_name","-c")
-		check_if_flag_is_provided(opts.out_dir,"out_dir","-o")
-		make_dir_if_not_made(opts.out_dir)
+        check_if_flag_is_provided(opts.dir_of_input_data,"dir_of_input_data","-i")
+        check_if_flag_is_provided(opts.refname,"refname","-r")
+        check_if_flag_is_provided(opts.center_name,"center_name","-c")
+        check_if_flag_is_provided(opts.out_dir,"out_dir","-o")
+        make_dir_if_not_made(opts.out_dir)
 
-		populate_data_to_ENA.run_xml(opts.dir_of_input_data,opts.refname,opts.center_name,opts.filetype,opts.out_dir)
+        populate_data_to_ENA.run_xml(opts.dir_of_input_data,opts.refname,opts.center_name,opts.filetype,opts.out_dir, opts.fastq_ends)
 
-		print "\nYour", opts.generate_xml_file_for,".xml file have been generated successfully in", opts.out_dir
+        print "\nYour", opts.generate_xml_file_for,".xml file have been generated successfully in", opts.out_dir
 
-	elif opts.generate_xml_file_for == "study":
-		
-		print "\nYou would like me to generate the", opts.generate_xml_file_for, ".xml file needed to submit your data to ENA....\nLet me check if you have provided all the necessary information....\n"
+    elif opts.generate_xml_file_for == "study":
 
-		check_if_flag_is_provided(opts.refname,"refname","-r")
-		check_if_flag_is_provided(opts.center_name,"center_name","-c")
-		check_if_flag_is_provided(opts.title_and_abstract_file,"title_and_abstract_file","-a")
-		check_if_flag_is_provided(opts.out_dir,"out_dir","-o")
-		make_dir_if_not_made(opts.out_dir)
+        print "\nYou would like me to generate the", opts.generate_xml_file_for, ".xml file needed to submit your data to ENA....\nLet me check if you have provided all the necessary information....\n"
 
-		populate_data_to_ENA.study_xml(opts.title_and_abstract_file,opts.center_name,opts.refname,opts.out_dir)
+        check_if_flag_is_provided(opts.refname,"refname","-r")
+        check_if_flag_is_provided(opts.center_name,"center_name","-c")
+        check_if_flag_is_provided(opts.title_and_abstract_file,"title_and_abstract_file","-a")
+        check_if_flag_is_provided(opts.out_dir,"out_dir","-o")
+        make_dir_if_not_made(opts.out_dir)
 
-		print "\nYour", opts.generate_xml_file_for,".xml file have been generated successfully in", opts.out_dir
+        populate_data_to_ENA.study_xml(opts.title_and_abstract_file,opts.center_name,opts.refname,opts.out_dir)
 
-	elif opts.generate_xml_file_for == "submission":
-		
-		print "\nYou would like me to generate the", opts.generate_xml_file_for, ".xml file needed to submit your data to ENA....\nLet me check if you have provided all the necessary information....\n"
+        print "\nYour", opts.generate_xml_file_for,".xml file have been generated successfully in", opts.out_dir
 
-		check_if_flag_is_provided(opts.refname,"refname","-r")
-		check_if_flag_is_provided(opts.center_name,"center_name","-c")
-		check_if_flag_is_provided(opts.out_dir,"out_dir","-o")
-		make_dir_if_not_made(opts.out_dir)
+    elif opts.generate_xml_file_for == "submission":
 
-		populate_data_to_ENA.submission_xml(opts.refname,opts.center_name,opts.out_dir,opts.release,opts.hold_date)
+        print "\nYou would like me to generate the", opts.generate_xml_file_for, ".xml file needed to submit your data to ENA....\nLet me check if you have provided all the necessary information....\n"
 
-		print "\nYour", opts.generate_xml_file_for,".xml file have been generated successfully in", opts.out_dir
+        check_if_flag_is_provided(opts.refname,"refname","-r")
+        check_if_flag_is_provided(opts.center_name,"center_name","-c")
+        check_if_flag_is_provided(opts.out_dir,"out_dir","-o")
+        make_dir_if_not_made(opts.out_dir)
 
-	elif opts.generate_xml_file_for == "all":
-		check_if_flag_is_provided(opts.dir_of_input_data,"dir_of_input_data","-i")
-		check_if_flag_is_provided(opts.refname,"refname","-r")
-		check_if_flag_is_provided(opts.center_name,"center_name","-c")
-		check_if_flag_is_provided(opts.data_file,"data_file","-f")
-		check_if_flag_is_provided(opts.title_and_abstract_file,"title_and_abstract_file","-a")
-		check_if_flag_is_provided(opts.out_dir,"out_dir","-o")	
-		make_dir_if_not_made(opts.out_dir)
+        populate_data_to_ENA.submission_xml(opts.refname,opts.center_name,opts.out_dir,opts.release,opts.hold_date)
 
-		populate_data_to_ENA.check_data_file(opts.data_file)
-		populate_data_to_ENA.sample_xml(opts.dir_of_input_data,opts.refname,opts.data_file,opts.center_name,opts.out_dir)
-		populate_data_to_ENA.experiment_xml(opts.dir_of_input_data,opts.data_file,opts.refname,opts.center_name,opts.library_strategy,opts.library_source,opts.library_selection,opts.read_length,opts.read_sdev,opts.instrument_model,opts.out_dir)
-		populate_data_to_ENA.run_xml(opts.dir_of_input_data,opts.refname,opts.center_name,opts.filetype,opts.out_dir)
-		populate_data_to_ENA.study_xml(opts.title_and_abstract_file,opts.center_name,opts.refname,opts.out_dir)
-		populate_data_to_ENA.submission_xml(opts.refname,opts.center_name,opts.out_dir,opts.hold_date)
+        print "\nYour", opts.generate_xml_file_for,".xml file have been generated successfully in", opts.out_dir
 
-	else:
-		print "You need any help?  Use the -h option."
+    elif opts.generate_xml_file_for == "all":
+        check_if_flag_is_provided(opts.dir_of_input_data,"dir_of_input_data","-i")
+        check_if_flag_is_provided(opts.refname,"refname","-r")
+        check_if_flag_is_provided(opts.center_name,"center_name","-c")
+        check_if_flag_is_provided(opts.data_file,"data_file","-f")
+        check_if_flag_is_provided(opts.title_and_abstract_file,"title_and_abstract_file","-a")
+        check_if_flag_is_provided(opts.out_dir,"out_dir","-o")
+        make_dir_if_not_made(opts.out_dir)
+
+        populate_data_to_ENA.check_data_file(opts.data_file)
+        populate_data_to_ENA.sample_xml(opts.dir_of_input_data,opts.refname,opts.data_file,opts.center_name,opts.out_dir, opts.fastq_ends)
+        populate_data_to_ENA.experiment_xml(opts.dir_of_input_data,opts.data_file,opts.refname,opts.center_name,opts.library_strategy,opts.library_source,opts.library_selection,opts.read_length,opts.read_sdev,opts.instrument_model, opts.fastq_ends, opts.out_dir)
+        populate_data_to_ENA.run_xml(opts.dir_of_input_data,opts.refname,opts.center_name,opts.filetype,opts.out_dir, opts.fastq_ends)
+        populate_data_to_ENA.study_xml(opts.title_and_abstract_file,opts.center_name,opts.refname,opts.out_dir)
+        populate_data_to_ENA.submission_xml(opts.refname,opts.center_name,opts.out_dir,opts.hold_date)
+
+    else:
+        print "You need any help?  Use the -h option."
 
 
 if __name__ == '__main__':
+    if sys.version_info.major != 2:
+        sys.exit('\n' + '"ena_submission.py" requires Python 2' + '\n' + 'Try running with "python2 ena_submission.py"')
     opts = set_up_argparse()
     main(opts)
+
+# TODO: check "|n" in README.md)

--- a/ena_submission.py
+++ b/ena_submission.py
@@ -191,7 +191,11 @@ Merge the remote changes before pushing again
     parser.add_argument('--do_everything', '-d', help='This option would run everything in one step, i.e: 1) Create checkums, 2) Uploads files to ENA ftp server, 3) Creats all the XML files, 4) Submits XML files to ENA (test only)',action='store_true')
     parser.add_argument('--generate_xml_file_for', '-x', help='please provide the name for the xml you like to generate, one of the following:all,experiment,run,sample,study,submission')
     parser.add_argument('--dir_of_input_data', '-i', help='please provide the path for the files you like to upload to ENA. NOTE: the fastq files must be in the following format: *.R1.fastq.gz and *.R2.fastq.gz.')
-    parser.add_argument('--data_file', '-f', help='data_file, file : this text file must have at least four columns seperated by TABS in the following order and with the following headings:  Column 1: SAMPLE, Column 2: TAXON_ID, Column 3: SCIENTIFIC_NAME, Column 4: DESCRIPTION.  If you like to add further data then add it after the DESCRIPTION column.')
+    parser.add_argument('--data_file', '-f',
+                        help='data_file, file : this text file must have at least four columns seperated by TABS in the'
+                             ' following order and with the following headings:  Column 1: sample_name,'
+                             ' Column 2: taxon, Column 3: organism, Column 4: description. If you like to add further'
+                             ' data then add it after the description column.')
     parser.add_argument('--ftp_user_name', '-user', help='please provide the ftp user name')
     parser.add_argument('--ftp_password', '-pass', help='please provide the ftp password')
     parser.add_argument('--title_and_abstract_file', '-a', help='please provide the title and abstract text file.  This is needed to generate the study.xml file.  The file should be in the following format: full title of the project\tabstract')
@@ -231,6 +235,16 @@ Merge the remote changes before pushing again
                              ' "_2.fastq.gz")',
                         required=False,
                         default=['.R1.fastq.gz', '.R2.fastq.gz'])
+    parser.add_argument('--sample_checklist',
+                        type=str,
+                        metavar='ERC000029',
+                        help='ENA provides sample checklists which define all the mandatory and recommended attributes'
+                             ' for specific types of samples. By declaring that you would like to register your samples'
+                             ' using a specific checklist you are enabling the samples to be validated for correctness'
+                             ' at submission time and are making it easier for other services to find and access the'
+                             ' sample attribute information.',
+                        required=False)
+
     opts = parser.parse_args()
 
     # Check --refname only contains one word
@@ -297,7 +311,8 @@ def main(opts):
         populate_data_to_ENA.check_abstract_file(opts.title_and_abstract_file)
         populate_data_to_ENA.create_checksums_file(opts.dir_of_input_data,opts.refname,opts.filetype, opts.fastq_ends)
         populate_data_to_ENA.upload_data_to_ena_ftp_server(opts.dir_of_input_data,opts.refname,opts.ftp_user_name,opts.ftp_password,opts.filetype, opts.fastq_ends)
-        populate_data_to_ENA.sample_xml(opts.dir_of_input_data,opts.refname,opts.data_file,opts.center_name,opts.out_dir, opts.fastq_ends)
+        populate_data_to_ENA.sample_xml(opts.dir_of_input_data, opts.refname, opts.data_file, opts.center_name,
+                                        opts.out_dir, opts.fastq_ends, opts.sample_checklist)
         populate_data_to_ENA.experiment_xml(opts.dir_of_input_data,opts.data_file,opts.refname,opts.center_name,opts.library_strategy,opts.library_source,opts.library_selection,opts.read_length,opts.read_sdev,opts.instrument_model, opts.fastq_ends, opts.out_dir)
         populate_data_to_ENA.run_xml(opts.dir_of_input_data,opts.refname,opts.center_name,opts.filetype,opts.out_dir, opts.fastq_ends)
         populate_data_to_ENA.study_xml(opts.title_and_abstract_file,opts.center_name,opts.refname,opts.out_dir)
@@ -325,7 +340,8 @@ def main(opts):
         make_dir_if_not_made(opts.out_dir)
 
         populate_data_to_ENA.check_data_file(opts.data_file)
-        populate_data_to_ENA.sample_xml(opts.dir_of_input_data,opts.refname,opts.data_file,opts.center_name,opts.out_dir, opts.fastq_ends)
+        populate_data_to_ENA.sample_xml(opts.dir_of_input_data, opts.refname, opts.data_file, opts.center_name,
+                                        opts.out_dir, opts.fastq_ends, opts.sample_checklist)
 
         print "\nYour", opts.generate_xml_file_for,".xml file have been generated successfully in", opts.out_dir
 
@@ -396,7 +412,8 @@ def main(opts):
         make_dir_if_not_made(opts.out_dir)
 
         populate_data_to_ENA.check_data_file(opts.data_file)
-        populate_data_to_ENA.sample_xml(opts.dir_of_input_data,opts.refname,opts.data_file,opts.center_name,opts.out_dir, opts.fastq_ends)
+        populate_data_to_ENA.sample_xml(opts.dir_of_input_data, opts.refname, opts.data_file, opts.center_name,
+                                        opts.out_dir, opts.fastq_ends, opts.sample_checklist)
         populate_data_to_ENA.experiment_xml(opts.dir_of_input_data,opts.data_file,opts.refname,opts.center_name,opts.library_strategy,opts.library_source,opts.library_selection,opts.read_length,opts.read_sdev,opts.instrument_model, opts.fastq_ends, opts.out_dir)
         populate_data_to_ENA.run_xml(opts.dir_of_input_data,opts.refname,opts.center_name,opts.filetype,opts.out_dir, opts.fastq_ends)
         populate_data_to_ENA.study_xml(opts.title_and_abstract_file,opts.center_name,opts.refname,opts.out_dir)

--- a/ena_submission.py
+++ b/ena_submission.py
@@ -219,8 +219,13 @@ Merge the remote changes before pushing again
     parser.add_argument('--read_sdev', '-sdev', help='Please provide the read stdv. default = 0.0', default='0.0')
     parser.add_argument('--instrument_model', '-m', help='please provide the name of the instrument model used. default = Illumina HiSeq 2500', default='Illumina HiSeq 2500')
     parser.add_argument('--filetype', '-F', help='Please provide the file type, default=fastq', default='fastq')
-    parser.add_argument('--hold_date', '-ho', help='This option will hold the data privately until a specified date.  Please provide the specified date using the following format: YYYY-MM-DD')
-    parser.add_argument('--release', '-R', help='This option will release the data immediatley to the public domain. Cannot be used with --hold_date. default = False', default=False, action='store_true')
+    parser.add_argument('--hold_date', '-ho', help='This option will hold the data privately until a specified date.'
+                                                   ' Please provide the specified date using the following format:'
+                                                   ' YYYY-MM-DD',
+                        required=False)
+    parser.add_argument('--release', '-R', help='This option will release the data immediatley to the public domain.'
+                                                ' Cannot be used with --hold_date. default = False', default=False,
+                        action='store_true')
     parser.add_argument('--curl_command', '-curl', help='Run curl command to upload everything to ENA',action='store_true')
     parser.add_argument('--create_checksums_file', '-cs', help='Create a checksum file',action='store_true')
     parser.add_argument('--upload_data_to_ena_ftp_server', '-ftp', help='Upload data into the ftp server',action='store_true')
@@ -316,7 +321,7 @@ def main(opts):
         populate_data_to_ENA.experiment_xml(opts.dir_of_input_data,opts.data_file,opts.refname,opts.center_name,opts.library_strategy,opts.library_source,opts.library_selection,opts.read_length,opts.read_sdev,opts.instrument_model, opts.fastq_ends, opts.out_dir)
         populate_data_to_ENA.run_xml(opts.dir_of_input_data,opts.refname,opts.center_name,opts.filetype,opts.out_dir, opts.fastq_ends)
         populate_data_to_ENA.study_xml(opts.title_and_abstract_file,opts.center_name,opts.refname,opts.out_dir)
-        populate_data_to_ENA.submission_xml(opts.refname,opts.center_name,opts.out_dir,opts.hold_date)
+        populate_data_to_ENA.submission_xml(opts.refname, opts.center_name, opts.out_dir, opts.release, opts.hold_date)
 
         print "\nAll your xml files have been generated successfully in", opts.out_dir, "\n"
 
@@ -398,7 +403,7 @@ def main(opts):
         check_if_flag_is_provided(opts.out_dir,"out_dir","-o")
         make_dir_if_not_made(opts.out_dir)
 
-        populate_data_to_ENA.submission_xml(opts.refname,opts.center_name,opts.out_dir,opts.release,opts.hold_date)
+        populate_data_to_ENA.submission_xml(opts.refname, opts.center_name, opts.out_dir, opts.release, opts.hold_date)
 
         print "\nYour", opts.generate_xml_file_for,".xml file have been generated successfully in", opts.out_dir
 
@@ -414,10 +419,14 @@ def main(opts):
         populate_data_to_ENA.check_data_file(opts.data_file)
         populate_data_to_ENA.sample_xml(opts.dir_of_input_data, opts.refname, opts.data_file, opts.center_name,
                                         opts.out_dir, opts.fastq_ends, opts.sample_checklist)
-        populate_data_to_ENA.experiment_xml(opts.dir_of_input_data,opts.data_file,opts.refname,opts.center_name,opts.library_strategy,opts.library_source,opts.library_selection,opts.read_length,opts.read_sdev,opts.instrument_model, opts.fastq_ends, opts.out_dir)
-        populate_data_to_ENA.run_xml(opts.dir_of_input_data,opts.refname,opts.center_name,opts.filetype,opts.out_dir, opts.fastq_ends)
+        populate_data_to_ENA.experiment_xml(opts.dir_of_input_data, opts.data_file, opts.refname, opts.center_name,
+                                            opts.library_strategy, opts.library_source, opts.library_selection,
+                                            opts.read_length, opts.read_sdev, opts.instrument_model, opts.fastq_ends,
+                                            opts.out_dir)
+        populate_data_to_ENA.run_xml(opts.dir_of_input_data,opts.refname,opts.center_name,opts.filetype,opts.out_dir,
+                                     opts.fastq_ends)
         populate_data_to_ENA.study_xml(opts.title_and_abstract_file,opts.center_name,opts.refname,opts.out_dir)
-        populate_data_to_ENA.submission_xml(opts.refname,opts.center_name,opts.out_dir,opts.hold_date)
+        populate_data_to_ENA.submission_xml(opts.refname, opts.center_name, opts.out_dir, opts.release, opts.hold_date)
 
     else:
         print "You need any help?  Use the -h option."

--- a/modules/populate_data_to_ENA.py
+++ b/modules/populate_data_to_ENA.py
@@ -427,9 +427,9 @@ def sample_xml(dir_of_input_data, refname, data_file, center_name, out_dir, fast
     sample_id_and_data = create_dict_with_data(dir_of_input_data, refname, data_file, fastq_ends)
     if {'sample_name', 'taxon', 'organism', 'description'} <= set(sample_id_and_data):
         sample_set = ET.Element('SAMPLE_SET')
-        sample_scientific_name_description = {'sample_name', 'taxon', 'organism', 'description'}
+        sample_scientific_name_description = ['sample_name', 'taxon', 'organism', 'description']
         all_keys_in_a_lits = set(sample_id_and_data.keys())
-        remaining_keys = all_keys_in_a_lits - sample_scientific_name_description
+        remaining_keys = all_keys_in_a_lits - set(sample_scientific_name_description)
 
         for index, sample_name in enumerate(sample_id_and_data["sample_name"]):
             for key in sample_scientific_name_description:

--- a/modules/populate_data_to_ENA.py
+++ b/modules/populate_data_to_ENA.py
@@ -19,8 +19,7 @@ import subprocess
 
 
 def check_file_exists(filepath, file_description):
-
-	"""
+    """
 	A function to check if a file exists.
 	It will print out an error message and exit if the file is not found
 
@@ -31,12 +30,13 @@ def check_file_exists(filepath, file_description):
 	file_description : String
 	    a description of the file to be checked e.g "config file"
 	"""
-	if not os.path.exists(filepath):
-		print("The " + file_description + " (" + filepath + ") does not exist")
-		sys.exit(1)
+    if not os.path.exists(filepath):
+        print("The " + file_description + " (" + filepath + ") does not exist")
+        sys.exit(1)
+
 
 def check_data_file(data_file):
-	"""
+    """
 	A function to check whether the data input file is in the right format or not.
 
 	Params
@@ -49,28 +49,29 @@ def check_data_file(data_file):
 
 
 	"""
-	meta_data_file = file(data_file, 'U')
-	# the data file should have this heading...
-	data_file_heading = ['SAMPLE', 'TAXON_ID', 'SCIENTIFIC_NAME', 'DESCRIPTION']
-	for lineNum, line in enumerate(meta_data_file):
-		if lineNum == 0:
-			headings_stripped = line.strip()
-			headings = headings_stripped.split(',')
-			# if the data_file_heading list has the heading in the data_file 
-			if set(headings).issuperset(set(data_file_heading)):
-				# Now compare the order...
-				if headings[0] == data_file_heading[0] and headings[1] == data_file_heading[1] and headings[2] == data_file_heading[2] and headings[3] == data_file_heading[3]:
-					print "Checking if data_file header order is correct....Yes"
-				else:
-					print "ERROR: The ORDER of the headers in the "+data_file+" file is incorrect.  You must have the following order: SAMPLE,TAXON_ID,SCIENTIFIC_NAME,DESCRIPTION."
-					sys.exit()
-			else:
-				print "ERROR: The headers in the "+data_file+" file are incorrect.  You must have the following data headers: SAMPLE,TAXON_ID,SCIENTIFIC_NAME,DESCRIPTION."
-				sys.exit()
+    meta_data_file = file(data_file, 'U')
+    # the data file should have this heading...
+    data_file_heading = ['SAMPLE', 'TAXON_ID', 'SCIENTIFIC_NAME', 'DESCRIPTION']
+    for lineNum, line in enumerate(meta_data_file):
+        if lineNum == 0:
+            headings_stripped = line.strip()
+            headings = headings_stripped.split('\t')
+            # if the data_file_heading list has the heading in the data_file
+            if set(headings).issuperset(set(data_file_heading)):
+                # Now compare the order...
+                if headings[0] == data_file_heading[0] and headings[1] == data_file_heading[1] and headings[2] == \
+                        data_file_heading[2] and headings[3] == data_file_heading[3]:
+                    print "Checking if data_file header order is correct....Yes"
+                else:
+                    print "ERROR: The ORDER of the headers in the " + data_file + " file is incorrect.  You must have the following order: SAMPLE,TAXON_ID,SCIENTIFIC_NAME,DESCRIPTION."
+                    sys.exit()
+            else:
+                print "ERROR: The headers in the " + data_file + " file are incorrect.  You must have the following data headers: SAMPLE,TAXON_ID,SCIENTIFIC_NAME,DESCRIPTION."
+                sys.exit()
+
 
 def check_abstract_file(title_and_abstract_file):
-	
-	'''
+    '''
 	check_abstract_file(title_and_abstract_file)
 
 	A function to check whether the title and abstract function is in the correct format.
@@ -85,21 +86,42 @@ def check_abstract_file(title_and_abstract_file):
     None
 
 	'''
-	try:
-		with open(title_and_abstract_file, 'U') as f:
-		    lines = f.readlines()
-		    for line in lines:
-				cols = line.decode('utf-8').strip().split('\t')
-				title = cols[0]
-				abstract = cols[1]
-		print "Checking if title and abstract file is in the correct format....Yes"
-	except:
-		print "Something is wrong with the title and abstract file " + title_and_abstract_file + ". It should have a title with a tab separator and abstract.  The file should only have one line. Please check and re-submit."
-		sys.exit()
+    try:
+        with open(title_and_abstract_file, 'U') as f:
+            lines = f.readlines()
+            for line in lines:
+                cols = line.decode('utf-8').strip().split('\t')
+                title = cols[0]
+                abstract = cols[1]
+        print "Checking if title and abstract file is in the correct format....Yes"
+    except:
+        print "Something is wrong with the title and abstract file " + title_and_abstract_file + ". It should have a title with a tab separator and abstract.  The file should only have one line. Please check and re-submit."
+        sys.exit()
 
-def create_checksums_file(dir_of_input_data,refname,filetype):
 
-	'''
+def rchop(string, ending):
+    """
+    This function removes the ending of a string
+
+    Parameters
+    ----------
+    string : str
+        String from which the ending part will be removed, e.g. 'sample_1.fastq.gz'
+    ending : str
+        Ending part of the string to be removed, e.g. '_1.fastq.gz'
+
+    Returns
+    -------
+    string : str
+        The original string without the ending part, e.g. 'sample'
+    """
+    if string.endswith(ending):
+        string = string[:-len(ending)]
+    return string
+
+
+def create_checksums_file(dir_of_input_data, refname, filetype, fastq_ends):
+    '''
 	create_checksums_file(dir_of_input_data,refname)
 
 	This function creates the checksum file of all the files to be submitted to ENA.  The fastq files MUST begin with the sample name and end with R1.fastq.gz or R2.fastq.gz and must be seperated by dots, e.g. my_sample.whatever.R1.fastq.gz
@@ -108,6 +130,8 @@ def create_checksums_file(dir_of_input_data,refname,filetype):
     ------
     dir_of_input_data, dir: This is the directory that contains all the files to be uploaded to ENA.  NOTE: the fastq files must be in the following format: *.R1.fastq.gz and *.R2.fastq.gz.
     refname, str: You must provide a reference name for your study, e.g. phe_ecoli
+    filetype, str: Type of files to submit, e.g. 'fastq'
+    fastq_ends, tuple: Tuple of strings of size 2 with fastq files end, e.g. ('.R1.fastq.gz', '.R2.fastq.gz')
 
     return
     ------
@@ -115,47 +139,50 @@ def create_checksums_file(dir_of_input_data,refname,filetype):
     checksums_file, file : a checksum file will be created in the dir_of_input_data directory.  It would be called: refname_"checksums.md5".
 
 	'''
-	try:
-		if filetype == "fastq":
-			files = glob.glob(dir_of_input_data+"/"+"*.R1.fastq.gz")
-			num_files = len(files)*2
-		else:
-			files = glob.glob(dir_of_input_data+"/"+"*."+filetype)
-			num_files = len(files)
+    try:
+        if filetype == "fastq":
+            files = glob.glob(dir_of_input_data + "/*" + fastq_ends[0])
+            num_files = len(files) * 2
+        else:
+            files = glob.glob(dir_of_input_data + "/" + "*." + filetype)
+            num_files = len(files)
 
-		if not files:
-			print "The files in "+dir_of_input_data+" do not match the prefix.  Please check and try again. Note: if you are uploading other than fastq files please use the -F option to specify the prefix of your files, e.g. -F bam."
-			sys.exit()
+        if not files:
+            print "The files in " + dir_of_input_data + " do not match the prefix.  Please check and try again. Note: if you are uploading other than fastq files please use the -F option to specify the prefix of your files, e.g. -F bam."
+            sys.exit()
 
-		# find out if checksums has already been done first
-		if not os.path.exists(dir_of_input_data+'/'+refname+'_checksums.md5'):
-			checksums_file = open(dir_of_input_data+'/'+refname+'_checksums.md5', "w")
+        # find out if checksums has already been done first
+        if not os.path.exists(dir_of_input_data + '/' + refname + '_checksums.md5'):
+            checksums_file = open(dir_of_input_data + '/' + refname + '_checksums.md5', "w")
 
-			print "creating checksums....."
-			for file in files:
-				(SeqDir,seqFileName_R1) = os.path.split(file)
-				# get the sample name.  filenames must be in the following format: sample_name.R1.fastq.gz
-				sample_name = seqFileName_R1.split('.')[0]
-				checksum_main = hashlib.md5(open(file, 'rb').read()).hexdigest()
-				checksums_file.write(checksum_main+" "+seqFileName_R1+"\n")
-				if filetype == "fastq":
-					read_2_file = ''.join(glob.glob(SeqDir+"/"+sample_name+".R2.fastq.gz"))
-					checksum_read2 = hashlib.md5(open(read_2_file, 'rb').read()).hexdigest()
-					(SeqDir,seqFileName_R2) = os.path.split(read_2_file)
-					checksums_file.write(checksum_read2+" "+seqFileName_R2+"\n")
-			print "created checksums file.  It's located in "+dir_of_input_data+'/'+refname+'_checksums.md5'
-		else:
-			num_lines_in_checksums_file = sum(1 for line in open(dir_of_input_data+'/'+refname+'_checksums.md5'))
+            print "creating checksums....."
+            for file in files:
+                (SeqDir, seqFileName_R1) = os.path.split(file)
+                # get the sample name
+                if filetype == "fastq":
+                    sample_name = rchop(seqFileName_R1, fastq_ends[0])
+                else:
+                    sample_name = seqFileName_R1.split('.')[0]
+                checksum_main = hashlib.md5(open(file, 'rb').read()).hexdigest()
+                checksums_file.write(checksum_main + " " + seqFileName_R1 + "\n")
+                if filetype == "fastq":
+                    read_2_file = ''.join(glob.glob(SeqDir + "/" + sample_name + fastq_ends[1]))
+                    checksum_read2 = hashlib.md5(open(read_2_file, 'rb').read()).hexdigest()
+                    (SeqDir, seqFileName_R2) = os.path.split(read_2_file)
+                    checksums_file.write(checksum_read2 + " " + seqFileName_R2 + "\n")
+            print "created checksums file.  It's located in " + dir_of_input_data + '/' + refname + '_checksums.md5'
+        else:
+            num_lines_in_checksums_file = sum(1 for line in open(dir_of_input_data + '/' + refname + '_checksums.md5'))
 
-			if num_lines_in_checksums_file == num_files:
-				print "\nChecksums file has already been generated and fully populated!"
-	except IOError:
-		print "ERROR: Something has gone wrong with creating the checksums file.  Please check and re-submit."
-		sys.exit()
+            if num_lines_in_checksums_file == num_files:
+                print "\nChecksums file has already been generated and fully populated!"
+    except IOError:
+        print "ERROR: Something has gone wrong with creating the checksums file.  Please check and re-submit."
+        sys.exit()
 
-def upload_data_to_ena_ftp_server(dir_of_input_data,refname,ftp_user_name,ftp_password,filetype):
 
-	'''
+def upload_data_to_ena_ftp_server(dir_of_input_data, refname, ftp_user_name, ftp_password, filetype, fastq_ends):
+    '''
 	upload_data_to_ena_ftp_server(dir_of_input_data,refname,ftp_user_name,ftp_password)
 
 	This function uploads the data to the ena ftp server.
@@ -166,6 +193,7 @@ def upload_data_to_ena_ftp_server(dir_of_input_data,refname,ftp_user_name,ftp_pa
     refname, str: You must provide a reference name for your study, e.g. phe_ecoli
     ftp_user_name, str: You must provide your ENA ftp username, e.g. Webin-40432
     ftp_password, str: You must provide your ENA ftp password
+    fastq_ends, tuple: Tuple of strings of size 2 with fastq files end, e.g. ('.R1.fastq.gz', '.R2.fastq.gz')
 
     return
     ------
@@ -174,81 +202,81 @@ def upload_data_to_ena_ftp_server(dir_of_input_data,refname,ftp_user_name,ftp_pa
 
 	'''
 
-	try:
-		print "\nconnecting to ftp.webin.ebi.ac.uk...."
-		ftp = ftplib.FTP("webin.ebi.ac.uk",ftp_user_name, ftp_password)
-	except IOError:
-		print(ftp.lastErrorText())
-		print "ERROR: could not connect to the ftp server.  Please check your login details."
-		sys.exit()
+    try:
+        print "\nconnecting to ftp.webin.ebi.ac.uk...."
+        ftp = ftplib.FTP("webin.ebi.ac.uk", ftp_user_name, ftp_password)
+    except IOError:
+        print(ftp.lastErrorText())
+        print "ERROR: could not connect to the ftp server.  Please check your login details."
+        sys.exit()
 
-	# print ftp.sendcmd('SITE CHMOD 644 ' + ftp.cwd())
-	print "\nSuccess!\n"
+    # print ftp.sendcmd('SITE CHMOD 644 ' + ftp.cwd())
+    print "\nSuccess!\n"
 
-	try:
-		if refname in ftp.nlst() :
-			print refname, "directory in ftp already exists....OK no problem..."
-			ftp.cwd(str(refname))
-		else:
-			print "\nmaking new directory in ftp called", refname
-			ftp.mkd(str(refname))
-			ftp.cwd(str(refname))
-		
-		check_file_exists(dir_of_input_data+'/'+refname+'_checksums.md5', 'checksum_file')
-		checksum_file = open(dir_of_input_data+'/'+refname+'_checksums.md5','rb')       # file to send
+    try:
+        if refname in ftp.nlst():
+            print refname, "directory in ftp already exists....OK no problem..."
+            ftp.cwd(str(refname))
+        else:
+            print "\nmaking new directory in ftp called", refname
+            ftp.mkd(str(refname))
+            ftp.cwd(str(refname))
 
-		print "\nuploading checksum file to ENA ftp server in the", refname, "directory\n"
+        check_file_exists(dir_of_input_data + '/' + refname + '_checksums.md5', 'checksum_file')
+        checksum_file = open(dir_of_input_data + '/' + refname + '_checksums.md5', 'rb')  # file to send
 
-		ftp.storbinary('STOR '+refname+'_checksums.md5', checksum_file)     # send the file
-		checksum_file.close()
-	except IOError:
-		print "ERROR: could not find the checksum file.  I'm looking for",dir_of_input_data+'/'+refname+'_checksums.md5'
-		sys.exit()
-	
-	print "Now uploading all the data to ENA ftp server in the", refname, "directory\n"
+        print "\nuploading checksum file to ENA ftp server in the", refname, "directory\n"
 
-	# added a while loop so if ftp fails it can try again.
-	# print ftplib.FTP.dir(ftp)
-	# ftp.cwd(str(refname))
+        ftp.storbinary('STOR ' + refname + '_checksums.md5', checksum_file)  # send the file
+        checksum_file.close()
+    except IOError:
+        print "ERROR: could not find the checksum file.  I'm looking for", dir_of_input_data + '/' + refname + '_checksums.md5'
+        sys.exit()
 
-	for i in range(0,3):
-		try:
-			if filetype == "fastq":
-				files = glob.glob(dir_of_input_data+"/"+"*.fastq.gz")
-			else:
-				files = glob.glob(dir_of_input_data+"/"+"*."+filetype)
-			
-			for file in files:
-				
-				(SeqDir,seqFileName) = os.path.split(file)
-				# if the sample has already been uploaded, check the file size number. If its the same as the dir file size then move on otherwise upload it again.
-				if seqFileName in ftp.nlst():
+    print "Now uploading all the data to ENA ftp server in the", refname, "directory\n"
 
-					fileSize_in_ftp = ftp.size(seqFileName)
-					fileSize_in_dir = os.path.getsize(str(file))
-					if fileSize_in_dir != fileSize_in_ftp:
-						print seqFileName+" is uploaded but not all of it so uploading it again now to ENA ftp server.\n"
-						ftp.storbinary('STOR '+seqFileName, open(file, 'rb'))
-					else:
-						print seqFileName + " has already been uploaded.\n"
-				else:
-					print "uploading", file, "to ENA ftp server.\n"
-					ftp.storbinary('STOR '+seqFileName, open(file, 'rb'))
-			break
-		except:
-			print "Something went wrong with ftp, lets try again...."
-	else:
-		print "Oops! something has gone wrong while uploading data to the ENA ftp server!"
-		sys.exit()
-			
-	
-	ftp.quit()
+    # added a while loop so if ftp fails it can try again.
+    # print ftplib.FTP.dir(ftp)
+    # ftp.cwd(str(refname))
 
-	
-	
+    for i in range(0, 3):
+        try:
+            if filetype == "fastq":
+                files = [os.path.join(dir_of_input_data, f) for f in os.listdir(dir_of_input_data)
+                         if not f.startswith('.')
+                         and os.path.isfile(os.path.join(dir_of_input_data, f))
+                         and f.endswith(fastq_ends)]
+            else:
+                files = glob.glob(dir_of_input_data + "/" + "*." + filetype)
+
+            for file in files:
+
+                (SeqDir, seqFileName) = os.path.split(file)
+                # if the sample has already been uploaded, check the file size number. If its the same as the dir file size then move on otherwise upload it again.
+                if seqFileName in ftp.nlst():
+                    fileSize_in_ftp = ftp.size(seqFileName)
+                    fileSize_in_dir = os.path.getsize(str(file))
+                    if fileSize_in_dir != fileSize_in_ftp:
+                        print seqFileName + " is uploaded but not all of it so uploading it again now to ENA ftp server.\n"
+                        ftp.storbinary('STOR ' + seqFileName, open(file, 'rb'))
+                    else:
+                        print seqFileName + " has already been uploaded.\n"
+                else:
+                    print "uploading", file, "to ENA ftp server.\n"
+                    ftp.storbinary('STOR ' + seqFileName, open(file, 'rb'))
+            break
+        except Exception as e:
+            print(e)
+            print "Something went wrong with ftp, lets try again...."
+    else:
+        print "Oops! something has gone wrong while uploading data to the ENA ftp server!"
+        sys.exit()
+
+    ftp.quit()
+
+
 def indent(elem, level=0):
-	
-	'''
+    '''
 	indent(elem, level=0)
 
 	This function indents the xml files to the appropriate indentations.
@@ -264,24 +292,23 @@ def indent(elem, level=0):
 
 	'''
 
-	i = "\n" + level*"  "
-	if len(elem):
-  		if not elem.text or not elem.text.strip():
-			elem.text = i + "  "
-		if not elem.tail or not elem.tail.strip():
-			elem.tail = i
-		for elem in elem:
-			indent(elem, level+1)
-		if not elem.tail or not elem.tail.strip():
-			elem.tail = i
-	else:
-		if level and (not elem.tail or not elem.tail.strip()):
-			elem.tail = i
+    i = "\n" + level * "  "
+    if len(elem):
+        if not elem.text or not elem.text.strip():
+            elem.text = i + "  "
+        if not elem.tail or not elem.tail.strip():
+            elem.tail = i
+        for elem in elem:
+            indent(elem, level + 1)
+        if not elem.tail or not elem.tail.strip():
+            elem.tail = i
+    else:
+        if level and (not elem.tail or not elem.tail.strip()):
+            elem.tail = i
 
 
-def create_dict_with_data(dir_of_input_data,refname,data_file, delim="\t", header=True):
-
-	'''
+def create_dict_with_data(dir_of_input_data, refname, data_file, fastq_ends, header=True):
+    '''
 	create_dict_with_data(dir_of_input_data,refname,data_file)
 
 	This function uses the data file provided and creates a dictionary to be used to create some xml files. The order of the rows is respected.
@@ -292,6 +319,7 @@ def create_dict_with_data(dir_of_input_data,refname,data_file, delim="\t", heade
 	refname, str: You must provide a reference name for your study, e.g. phe_ecoli
 	data_file, file : this csv file must have at least three columns seperated by commas in the following order and with the following headings:  Column 1: SAMPLE, Column 2: TAXON_ID, Column 3: SCIENTIFIC_NAME, Column 4: DESCRIPTION.  If you like to add further data then add it after the DESCRIPTION column.
 	header, True or False :  if True the first line will be considered a header line
+    fastq_ends, tuple: Tuple of strings of size 2 with fastq files end, e.g. ('.R1.fastq.gz', '.R2.fastq.gz')
 
 
 	return
@@ -300,59 +328,65 @@ def create_dict_with_data(dir_of_input_data,refname,data_file, delim="\t", heade
 	sample_id_and_data, dict : a dictionary that has the headings as keys and the data as values.
 
 	'''
-    
-	meta_data_file = file(data_file, 'U')
-	cols = {}
-	indexToName = {}
-    
-	with open(dir_of_input_data+'/'+refname+'_checksums.md5','rb') as f:
-		sample_id_and_data = []
-		for l in f:
-			splitLine = l.split()
-			sample_name_split = splitLine[1].split(".")
-			sample_id_and_data.append(str(sample_name_split[0]))
-			# values are nil at the moment as we will populate them only if there is a data_file provided.
-			# sample_id_and_data[str(sample_name_split[0])] = ""
 
-	strain_names = set(sample_id_and_data)
+    meta_data_file = file(data_file, 'U')
+    cols = {}
+    indexToName = {}
 
-	for lineNum, line in enumerate(meta_data_file):
-		if lineNum == 0:
-			headings = line.split(',')
-			i = 0
-			for heading in headings:
-				heading = heading.strip()
-				if header:
-					cols[heading] = []
-					indexToName[i] = heading
-				else:
-					# in this case the heading is actually just a cell
-					cols[i] = [heading]
-					indexToName[i] = i
-				i += 1
-		else:
-			strip_line = line.strip()
-			# cells is a list of each of the lines in the data file, e.g. ['ST38_21', '562', 'Escherichia coli', 'OXA-48 producer', 'North West_3', '28_2014']
-			cells = strip_line.split(',')
-			x = 0
-			# if the sample name (cells[0]) is in the strain names obtained from the checksums file then add to dict cols 
-			if cells[0] in strain_names:
-				try:
-					for cell in cells:
-						cell = cell.rstrip()
-						#indexToName[i] is the header name index
-						cols[indexToName[x]] += [cell]
-						x += 1
-				except EOFError:
-					print "ERROR: something is wrong with the "+data_file+" file."
-			else:
-				print "ERROR: "+cells[0]+" from the "+data_file+" is not equivalent to the sample name you have labelled your files in"+"".join(strain_names)
-				sys.exit()
-	return cols
+    with open(dir_of_input_data + '/' + refname + '_checksums.md5', 'rb') as f:
+        sample_id_and_data = []
+        for line in f:
+            line = line.split()[1]
+            for fastq_end in fastq_ends:
+                sample_name = rchop(line, fastq_end)
+                if len(sample_name) < len(line):
+                    sample_id_and_data.append(sample_name)
+                    break
+        # values are nil at the moment as we will populate them only if there is a data_file provided.
+        # sample_id_and_data[str(sample_name_split[0])] = ""
 
-def sample_xml(dir_of_input_data,refname,data_file,center_name,out_dir):
-	
-	'''
+    strain_names = set(sample_id_and_data)
+
+    for lineNum, line in enumerate(meta_data_file):
+        if lineNum == 0:
+            headings = line.split('\t')
+            i = 0
+            for heading in headings:
+                heading = heading.strip()
+                if header:
+                    cols[heading] = []
+                    indexToName[i] = heading
+                else:
+                    # in this case the heading is actually just a cell
+                    cols[i] = [heading]
+                    indexToName[i] = i
+                i += 1
+        else:
+            strip_line = line.strip()
+            # cells is a list of each of the lines in the data file, e.g. ['ST38_21', '562', 'Escherichia coli', 'OXA-48 producer', 'North West_3', '28_2014']
+            cells = strip_line.split('\t')
+            x = 0
+            # if the sample name (cells[0]) is in the strain names obtained from the checksums file then add to dict cols
+            if cells[0] in strain_names:
+                try:
+                    for cell in cells:
+                        cell = cell.rstrip()
+                        # indexToName[i] is the header name index
+                        cols[indexToName[x]] += [cell]
+                        x += 1
+                except EOFError:
+                    print "ERROR: something is wrong with the " + data_file + " file."
+            else:
+                msg = 'ERROR: {sample} from the {data_file} is not equivalent to samples name you have labelled your' \
+                      ' sequecing files in:\n' \
+                      '{samples_files}'.format(sample=cells[0], data_file=data_file,
+                                               samples_files='\n'.join(strain_names))
+                sys.exit(msg)
+    return cols
+
+
+def sample_xml(dir_of_input_data, refname, data_file, center_name, out_dir, fastq_ends):
+    '''
 	create_checksums_file(dir_of_input_data,refname)
 
 	This function creates the checksum file of all the files to be submitted to ENA.
@@ -365,6 +399,7 @@ def sample_xml(dir_of_input_data,refname,data_file,center_name,out_dir):
     center_name, str : name of the center, e.g. PHE
     taxon_id, str : the taxon id of the organism from NCBI
     out_dir, str : path to the output directory where all the xml files will be added.
+    fastq_ends, tuple: Tuple of strings of size 2 with fastq files end, e.g. ('.R1.fastq.gz', '.R2.fastq.gz')
 
     return
     ------
@@ -373,66 +408,66 @@ def sample_xml(dir_of_input_data,refname,data_file,center_name,out_dir):
 
  	'''
 
-	sample_id_and_data = create_dict_with_data(dir_of_input_data,refname,data_file)
-	# print sample_id_and_data
-	if set(('SAMPLE','TAXON_ID','SCIENTIFIC_NAME','DESCRIPTION')) <= set(sample_id_and_data):
-		sample_set = ET.Element('SAMPLE_SET')
-		sample_scientific_name_description = set(['SAMPLE','TAXON_ID','SCIENTIFIC_NAME','DESCRIPTION'])
-		all_keys_in_a_lits = set(sample_id_and_data.keys())
-		remaining_keys = all_keys_in_a_lits - sample_scientific_name_description
+    sample_id_and_data = create_dict_with_data(dir_of_input_data, refname, data_file, fastq_ends)
+    if set(('SAMPLE', 'TAXON_ID', 'SCIENTIFIC_NAME', 'DESCRIPTION')) <= set(sample_id_and_data):
+        sample_set = ET.Element('SAMPLE_SET')
+        sample_scientific_name_description = set(['SAMPLE', 'TAXON_ID', 'SCIENTIFIC_NAME', 'DESCRIPTION'])
+        all_keys_in_a_lits = set(sample_id_and_data.keys())
+        remaining_keys = all_keys_in_a_lits - sample_scientific_name_description
 
-		for index,sample_name in enumerate(sample_id_and_data["SAMPLE"]):
-			for key in sample_scientific_name_description:
-				field = []
-				field.append(sample_id_and_data[key][index])
-				# begin with indentation of the xml file.  start with sample...
-				if key == "SAMPLE":
-					sample = ET.SubElement(sample_set, 'SAMPLE', alias=''.join(field), center_name=center_name)
-					# and then title
-					title = ET.SubElement(sample, "TITLE").text = ''.join(field)
-					sample_name = ET.SubElement(sample, "SAMPLE_NAME")
-					# for below only use if you want to update and have isolate ena number
-					# scientific and description are optional.  If they included in the data_file then they will be populated, otherwise they will be left empty.
-				elif key == "TAXON_ID":
-					taxon = ET.SubElement(sample_name, "TAXON_ID").text = ''.join(field)
+        for index, sample_name in enumerate(sample_id_and_data["SAMPLE"]):
+            for key in sample_scientific_name_description:
+                field = []
+                field.append(sample_id_and_data[key][index])
+                # begin with indentation of the xml file.  start with sample...
+                if key == "SAMPLE":
+                    sample = ET.SubElement(sample_set, 'SAMPLE', alias=''.join(field), center_name=center_name)
+                    # and then title
+                    title = ET.SubElement(sample, "TITLE").text = ''.join(field)
+                    sample_name = ET.SubElement(sample, "SAMPLE_NAME")
+                # for below only use if you want to update and have isolate ena number
+                # scientific and description are optional.  If they included in the data_file then they will be populated, otherwise they will be left empty.
+                elif key == "TAXON_ID":
+                    taxon = ET.SubElement(sample_name, "TAXON_ID").text = ''.join(field)
 
-				elif key == "SCIENTIFIC_NAME":
-					scientific = ET.SubElement(sample_name, "SCIENTIFIC_NAME").text = ''.join(field)
+                elif key == "SCIENTIFIC_NAME":
+                    scientific = ET.SubElement(sample_name, "SCIENTIFIC_NAME").text = ''.join(field)
 
-				elif key == "DESCRIPTION":
-					desc = ET.SubElement(sample, "DESCRIPTION").text = ''.join(field)
-			
-			# only add sample attributes if required
-			if len(remaining_keys) > 0:	
-				sample_attributes = ET.SubElement(sample, "SAMPLE_ATTRIBUTES")
+                elif key == "DESCRIPTION":
+                    desc = ET.SubElement(sample, "DESCRIPTION").text = ''.join(field)
 
-				for key in remaining_keys:
-					field = []
-					field.append(sample_id_and_data[key][index])
-					# for below only use if you want to update and have isolate ena number
-					sample_attribute = ET.SubElement(sample_attributes, "SAMPLE_ATTRIBUTE")
-					# tag = ET.SubElement(sample_attribute, "TAG").text = "SAMPLE"
-					# value = ET.SubElement(sample_attribute, "VALUE").text = str(sample_name)
-					tag = ET.SubElement(sample_attribute, "TAG").text = str(key)
-					value = ET.SubElement(sample_attribute, "VALUE").text = ''.join(field)
-					# use the indent function to indent the xml file
-	else:
-		print "ERROR: The " + data_file + " file does not contain one of the following fields: SAMPLE, TAXON_ID, SCIENTIFIC_NAME, DESCRIPTION. Please add the relevant field to proceed...."
-		sys.exit(1)
-	# print sample_id_and_data
-	indent(sample_set)
-	# create tree
-	tree = ET.ElementTree(sample_set)
+            # only add sample attributes if required
+            if len(remaining_keys) > 0:
+                sample_attributes = ET.SubElement(sample, "SAMPLE_ATTRIBUTES")
 
-	# out_dirput to outfile
-	with open(out_dir+"/sample.xml", 'w') as outfile:
-		tree.write(outfile, xml_declaration=True, encoding='utf-8', method="xml")
+                for key in remaining_keys:
+                    field = []
+                    field.append(sample_id_and_data[key][index])
+                    # for below only use if you want to update and have isolate ena number
+                    sample_attribute = ET.SubElement(sample_attributes, "SAMPLE_ATTRIBUTE")
+                    # tag = ET.SubElement(sample_attribute, "TAG").text = "SAMPLE"
+                    # value = ET.SubElement(sample_attribute, "VALUE").text = str(sample_name)
+                    tag = ET.SubElement(sample_attribute, "TAG").text = str(key)
+                    value = ET.SubElement(sample_attribute, "VALUE").text = ''.join(field)
+                # use the indent function to indent the xml file
+    else:
+        print "ERROR: The " + data_file + " file does not contain one of the following fields: SAMPLE, TAXON_ID, SCIENTIFIC_NAME, DESCRIPTION. Please add the relevant field to proceed...."
+        sys.exit(1)
+    # print sample_id_and_data
+    indent(sample_set)
+    # create tree
+    tree = ET.ElementTree(sample_set)
 
-	print "\nSuccessfully created sample.xml file\n"
+    # out_dirput to outfile
+    with open(out_dir + "/sample.xml", 'w') as outfile:
+        tree.write(outfile, xml_declaration=True, encoding='utf-8', method="xml")
 
-def experiment_xml(dir_of_input_data,data_file,refname,center_name,library_strategy,library_source,library_selection,read_length,read_sdev,instrument_model,out_dir=""):
-	
-	'''
+    print "\nSuccessfully created sample.xml file\n"
+
+
+def experiment_xml(dir_of_input_data, data_file, refname, center_name, library_strategy, library_source,
+                   library_selection, read_length, read_sdev, instrument_model, fastq_ends, out_dir=""):
+    '''
 	experiment_xml(dir_of_input_data,data_file,refname,center_name,library_strategy,library_source,library_selection,read_length,read_sdev,instrument_model,out_dir=""):
 	This function generates a experiment xml file needed for submission of data to ENA.  It will contain a subelement for each sample provided in the data_file.
 
@@ -449,6 +484,7 @@ def experiment_xml(dir_of_input_data,data_file,refname,center_name,library_strat
     read_sdev, int : default 0.0
     instrument_model, int : default "Illumina HiSeq 2500"
     out_dir, str : name of the new xml file
+    fastq_ends, tuple: Tuple of strings of size 2 with fastq files end, e.g. ('.R1.fastq.gz', '.R2.fastq.gz')
 
     return
     ------
@@ -456,54 +492,54 @@ def experiment_xml(dir_of_input_data,data_file,refname,center_name,library_strat
     outfile, file : a experiment xml file needed for ENA submission.
 
 	'''
-	sample_id_and_data = create_dict_with_data(dir_of_input_data,refname,data_file)
-	# set the root element
-	experiment_set = ET.Element('EXPERIMENT_SET')
+    sample_id_and_data = create_dict_with_data(dir_of_input_data, refname, data_file, fastq_ends)
+    # set the root element
+    experiment_set = ET.Element('EXPERIMENT_SET')
 
-	if "SAMPLE" not in sample_id_and_data:
-		print "The ",data_file, "file does not contain a SAMPLE field! Please add a SAMPLE field to proceed"
-		sys.exit(1)
-	else:
-		for index,isolate in enumerate(sample_id_and_data["SAMPLE"]):
-			experiment = ET.SubElement(experiment_set, 'EXPERIMENT', alias=isolate, center_name=center_name)
-			study_ref = ET.SubElement(experiment, "STUDY_REF", refname=refname, refcenter=center_name)
-			# indent
-			design = ET.SubElement(experiment, "DESIGN")
-			# indent
-			design_description = ET.SubElement(design, "DESIGN_DESCRIPTION")
-			sample_descriptor = ET.SubElement(design, 'SAMPLE_DESCRIPTOR', refname=isolate, refcenter=center_name)
-			library_descriptor = ET.SubElement(design, "LIBRARY_DESCRIPTOR")
-			library_name = ET.SubElement(library_descriptor, "LIBRARY_NAME")
-			library_strategy = ET.SubElement(library_descriptor, "LIBRARY_STRATEGY").text = str(library_strategy)
-			library_source = ET.SubElement(library_descriptor, "LIBRARY_SOURCE").text = str(library_source)
-			library_selection = ET.SubElement(library_descriptor, "LIBRARY_SELECTION").text = str(library_selection)
-			library_layout_dir = ET.SubElement(library_descriptor, "LIBRARY_LAYOUT")
-			#indent
-			paired = ET.SubElement(library_layout_dir, "PAIRED", NOMINAL_LENGTH=read_length, NOMINAL_SDEV=read_sdev)
-			# dedent
-			platform = ET.SubElement(experiment, "PLATFORM")
-			illumina = ET.SubElement(platform, "ILLUMINA")
+    if "SAMPLE" not in sample_id_and_data:
+        print "The ", data_file, "file does not contain a SAMPLE field! Please add a SAMPLE field to proceed"
+        sys.exit(1)
+    else:
+        for index, isolate in enumerate(sample_id_and_data["SAMPLE"]):
+            experiment = ET.SubElement(experiment_set, 'EXPERIMENT', alias=isolate, center_name=center_name)
+            study_ref = ET.SubElement(experiment, "STUDY_REF", refname=refname, refcenter=center_name)
+            # indent
+            design = ET.SubElement(experiment, "DESIGN")
+            # indent
+            design_description = ET.SubElement(design, "DESIGN_DESCRIPTION")
+            sample_descriptor = ET.SubElement(design, 'SAMPLE_DESCRIPTOR', refname=isolate, refcenter=center_name)
+            library_descriptor = ET.SubElement(design, "LIBRARY_DESCRIPTOR")
+            library_name = ET.SubElement(library_descriptor, "LIBRARY_NAME")
+            library_strategy = ET.SubElement(library_descriptor, "LIBRARY_STRATEGY").text = str(library_strategy)
+            library_source = ET.SubElement(library_descriptor, "LIBRARY_SOURCE").text = str(library_source)
+            library_selection = ET.SubElement(library_descriptor, "LIBRARY_SELECTION").text = str(library_selection)
+            library_layout_dir = ET.SubElement(library_descriptor, "LIBRARY_LAYOUT")
+            # indent
+            paired = ET.SubElement(library_layout_dir, "PAIRED", NOMINAL_LENGTH=read_length, NOMINAL_SDEV=read_sdev)
+            # dedent
+            platform = ET.SubElement(experiment, "PLATFORM")
+            illumina = ET.SubElement(platform, "ILLUMINA")
 
-			#indent
-			instrument_model = ET.SubElement(illumina, "INSTRUMENT_MODEL").text = str(instrument_model)
+            # indent
+            instrument_model = ET.SubElement(illumina, "INSTRUMENT_MODEL").text = str(instrument_model)
 
-			# dedent
-			processing = ET.SubElement(experiment, "PROCESSING")
+            # dedent
+            processing = ET.SubElement(experiment, "PROCESSING")
 
-	# use the indent function to indent the xml file
-	indent(experiment_set)
-	# create tree
-	tree = ET.ElementTree(experiment_set)
+    # use the indent function to indent the xml file
+    indent(experiment_set)
+    # create tree
+    tree = ET.ElementTree(experiment_set)
 
-	# out_dirput to outfile
-	with open(out_dir+"/experiment.xml", 'w') as outfile:
-		tree.write(outfile, xml_declaration=True, encoding='utf-8', method="xml")
+    # out_dirput to outfile
+    with open(out_dir + "/experiment.xml", 'w') as outfile:
+        tree.write(outfile, xml_declaration=True, encoding='utf-8', method="xml")
 
-	print "\nSuccessfully created experiment.xml file\n"
+    print "\nSuccessfully created experiment.xml file\n"
 
-def run_xml(dir_of_input_data,refname,center_name,filetype,out_dir):
 
-	'''
+def run_xml(dir_of_input_data, refname, center_name, filetype, out_dir, fastq_ends):
+    '''
 	run_xml(dir_of_input_data,refname,center_name,filetype,out_dir):
 	
 	This function generates a run.xml file needed for submission of data to ENA.
@@ -515,6 +551,7 @@ def run_xml(dir_of_input_data,refname,center_name,filetype,out_dir):
     refname, str: A unique name for the whole submission. This name must not have been used before in any other submission to ENA.
     filetype, str: the default is fastq.
     out_dir, str : name of the new xml file
+    fastq_ends, tuple: Tuple of strings of size 2 with fastq files end, e.g. ('.R1.fastq.gz', '.R2.fastq.gz')
 
     return
     ------
@@ -523,47 +560,51 @@ def run_xml(dir_of_input_data,refname,center_name,filetype,out_dir):
 
 	'''
 
-	run_set = ET.Element('RUN_SET')
+    run_set = ET.Element('RUN_SET')
 
-	# open the checksum file and get the checksums and file names
-	with open(dir_of_input_data+'/'+refname+'_checksums.md5','rb') as f:
-		for line1 in f:
-			read1 = line1.split()
-			sample_name_split = read1[1].split(".")
-			sample_name = sample_name_split[0]
-			checksum_read1 = read1[0]
-			try:
-			# loop through every two lines, for read1 and read2
-				line2 = f.next()
-				read2 = line2.split()
-				checksum_read2 = read2[0]
-				# if there are pairs of reads
-				if sample_name in str(read2[1]):
-					run = ET.SubElement(run_set, 'RUN', alias=sample_name, center_name=center_name, run_center=center_name)
-					#indent
-					experiment_ref = ET.SubElement(run, 'EXPERIMENT_REF', refname=sample_name)
-					data_block = ET.SubElement(run, 'DATA_BLOCK')
-					files = ET.SubElement(data_block, 'FILES')
-					file1 = ET.SubElement(files, 'FILE', checksum=checksum_read1, checksum_method="MD5", filename=refname+"/"+read1[1], filetype=filetype)
-					file2 = ET.SubElement(files, 'FILE', checksum=checksum_read2, checksum_method="MD5", filename=refname+"/"+read2[1], filetype=filetype)
-			except StopIteration:
-				print "ERROR: no second read found for", sample_name
-				sys.exit() 
+    # open the checksum file and get the checksums and file names
+    with open(dir_of_input_data + '/' + refname + '_checksums.md5', 'rb') as f:
+        for line1 in f:
+            read1 = line1.split()
+            for fastq_end in fastq_ends:
+                sample_name = rchop(read1[1], fastq_end)
+                if len(sample_name) < len(read1[1]):
+                    break
+            checksum_read1 = read1[0]
 
-	# use the indent function to indent the xml file
-	indent(run_set)
-	# create tree
-	tree = ET.ElementTree(run_set)
+            # loop through every two lines, for read1 and read2
+            line2 = f.next()
+            read2 = line2.split()
+            checksum_read2 = read2[0]
+            # if there are pairs of reads
+            if sample_name in str(read2[1]):
+                run = ET.SubElement(run_set, 'RUN', alias=sample_name, center_name=center_name,
+                                    run_center=center_name)
+                # indent
+                experiment_ref = ET.SubElement(run, 'EXPERIMENT_REF', refname=sample_name)
+                data_block = ET.SubElement(run, 'DATA_BLOCK')
+                files = ET.SubElement(data_block, 'FILES')
+                file1 = ET.SubElement(files, 'FILE', checksum=checksum_read1, checksum_method="MD5",
+                                      filename=refname + "/" + read1[1], filetype=filetype)
+                file2 = ET.SubElement(files, 'FILE', checksum=checksum_read2, checksum_method="MD5",
+                                      filename=refname + "/" + read2[1], filetype=filetype)
+            else:
+                sys.exit("ERROR: no second read found for", sample_name)
 
-	# out_dirput to outfile
-	with open(out_dir+"/run.xml", 'w') as outfile:
-		tree.write(outfile, xml_declaration=True, encoding='utf-8', method="xml")
+            # use the indent function to indent the xml file
+    indent(run_set)
+    # create tree
+    tree = ET.ElementTree(run_set)
 
-	print "\nSuccessfully created run.xml file\n"
+    # out_dirput to outfile
+    with open(out_dir + "/run.xml", 'w') as outfile:
+        tree.write(outfile, xml_declaration=True, encoding='utf-8', method="xml")
 
-def study_xml(title_and_abstract_file,center_name,refname,out_dir):
+    print "\nSuccessfully created run.xml file\n"
 
-	'''
+
+def study_xml(title_and_abstract_file, center_name, refname, out_dir):
+    '''
 	study_xml(title_and_abstract_file,center_name,refname,center_project_name,out_dir):
 	
 	This function generates a study.xml file needed for submission of data to ENA.
@@ -583,40 +624,40 @@ def study_xml(title_and_abstract_file,center_name,refname,out_dir):
 
 	'''
 
-	study_set = ET.Element('STUDY_SET')
-	try:
-		with open(title_and_abstract_file, 'r') as f:
-		    lines = f.readlines()
-		    for line in lines:
-				cols = line.decode('utf-8').strip().split('\t')
-				title = cols[0]
-				abstract = cols[1]
+    study_set = ET.Element('STUDY_SET')
+    try:
+        with open(title_and_abstract_file, 'r') as f:
+            lines = f.readlines()
+            for line in lines:
+                cols = line.decode('utf-8').strip().split('\t')
+                title = cols[0]
+                abstract = cols[1]
 
-				study = ET.SubElement(study_set, 'STUDY', alias=refname, center_name=center_name)
-				# indent
-				descriptor = ET.SubElement(study, 'DESCRIPTOR')
-				# indent
-				# center_project_name = ET.SubElement(descriptor, 'CENTER_PROJECT_NAME').text = center_project_name
-				study_title = ET.SubElement(descriptor, 'STUDY_TITLE').text = str(title)
-				study_type = ET.SubElement(descriptor, 'STUDY_TYPE', existing_study_type="Whole Genome Sequencing")
-				study_abstract = ET.SubElement(descriptor, 'STUDY_ABSTRACT').text = abstract
-	except EOFError:
-		print "problem with the title and abstract file!"
-		sys.exit()
-	# use the indent function to indent the xml file
-	indent(study_set)
-	# create tree
-	tree = ET.ElementTree(study_set)
+                study = ET.SubElement(study_set, 'STUDY', alias=refname, center_name=center_name)
+                # indent
+                descriptor = ET.SubElement(study, 'DESCRIPTOR')
+                # indent
+                # center_project_name = ET.SubElement(descriptor, 'CENTER_PROJECT_NAME').text = center_project_name
+                study_title = ET.SubElement(descriptor, 'STUDY_TITLE').text = str(title)
+                study_type = ET.SubElement(descriptor, 'STUDY_TYPE', existing_study_type="Whole Genome Sequencing")
+                study_abstract = ET.SubElement(descriptor, 'STUDY_ABSTRACT').text = abstract
+    except EOFError:
+        print "problem with the title and abstract file!"
+        sys.exit()
+    # use the indent function to indent the xml file
+    indent(study_set)
+    # create tree
+    tree = ET.ElementTree(study_set)
 
-	# out_dirput to outfile
-	with open(out_dir+"/study.xml", 'w') as outfile:
-		tree.write(outfile, xml_declaration=True, encoding='utf-8', method="xml")
+    # out_dirput to outfile
+    with open(out_dir + "/study.xml", 'w') as outfile:
+        tree.write(outfile, xml_declaration=True, encoding='utf-8', method="xml")
 
-	print "\nSuccessfully created study.xml file\n"
+    print "\nSuccessfully created study.xml file\n"
 
-def submission_xml(refname,center_name,out_dir,release=False,hold_date=''):
 
-	'''
+def submission_xml(refname, center_name, out_dir, release=False, hold_date=''):
+    '''
 	submission_xml(refname,center_name,out_dir,release,hold_date='')
 	
 	This function generates a submission.xml file needed for submission of data to ENA. It is the final of the five xml files needed.
@@ -637,40 +678,40 @@ def submission_xml(refname,center_name,out_dir,release=False,hold_date=''):
 
 	'''
 
-	xml_files = ["study", "sample", "experiment", "run"]
+    xml_files = ["study", "sample", "experiment", "run"]
 
-	submission_set = ET.Element('SUBMISSION_SET')
-	submission = ET.SubElement(submission_set, 'SUBMISSION', alias=refname, center_name=center_name)
-	actions = ET.SubElement(submission, "ACTIONS")
-	for xml_file in xml_files:
-		action = ET.SubElement(actions, "ACTION")
-		add = ET.SubElement(action, "ADD", source=xml_file+".xml", schema=xml_file)
+    submission_set = ET.Element('SUBMISSION_SET')
+    submission = ET.SubElement(submission_set, 'SUBMISSION', alias=refname, center_name=center_name)
+    actions = ET.SubElement(submission, "ACTIONS")
+    for xml_file in xml_files:
+        action = ET.SubElement(actions, "ACTION")
+        add = ET.SubElement(action, "ADD", source=xml_file + ".xml", schema=xml_file)
 
-	# if a hold date is given until releasing publicly
-	action = ET.SubElement(actions, "ACTION")
+    # if a hold date is given until releasing publicly
+    action = ET.SubElement(actions, "ACTION")
 
-	if hold_date:
-		hold = ET.SubElement(action, "HOLD", HoldUntilDate=hold_date)
-	# else if release is given, i.e. release immediatley to the public
-	elif release:
-		release = ET.SubElement(action, "RELEASE")
-	# otherwise hold for two years and then make it public
-	else:
-		hold = ET.SubElement(action, "HOLD")
-	# use the indent function to indent the xml file
-	indent(submission_set)
-	# create tree
-	tree = ET.ElementTree(submission_set)
+    if hold_date:
+        hold = ET.SubElement(action, "HOLD", HoldUntilDate=hold_date)
+    # else if release is given, i.e. release immediatley to the public
+    elif release:
+        release = ET.SubElement(action, "RELEASE")
+    # otherwise hold for two years and then make it public
+    else:
+        hold = ET.SubElement(action, "HOLD")
+    # use the indent function to indent the xml file
+    indent(submission_set)
+    # create tree
+    tree = ET.ElementTree(submission_set)
 
-	# out_dirput to outfile
-	with open(out_dir+"/submission.xml", 'w') as outfile:
-		tree.write(outfile, xml_declaration=True, encoding='utf-8', method="xml")
+    # out_dirput to outfile
+    with open(out_dir + "/submission.xml", 'w') as outfile:
+        tree.write(outfile, xml_declaration=True, encoding='utf-8', method="xml")
 
-	print "\nSuccessfully created submission.xml file\n"
+    print "\nSuccessfully created submission.xml file\n"
 
-def run_curl_command(ftp_user_name,ftp_password,out):
 
-	'''
+def run_curl_command(ftp_user_name, ftp_password, out):
+    '''
 	run_curl_command(ftp_user_name,ftp_password)
 	
 	This function executes the curl command that would upload all the xml files to ENA.  The function first runs a test command and if successfull automatically runs the production command.
@@ -688,26 +729,26 @@ def run_curl_command(ftp_user_name,ftp_password,out):
     receipt.xml, file: stdout of the curl command.
 
 	'''
-	# first do a test...
+    # first do a test...
 
-	test_cmd = "curl -k -F \"SUBMISSION=@submission.xml\" -F \"STUDY=@study.xml\" -F \"SAMPLE=@sample.xml\" -F \"EXPERIMENT=@experiment.xml\" -F \"RUN=@run.xml\" \"https://www-test.ebi.ac.uk/ena/submit/drop-box/submit/?auth=ENA%20\"" + ftp_user_name + "%20" + ftp_password
-	prod_cmd = "\ncurl -k -F \"SUBMISSION=@submission.xml\" -F \"STUDY=@study.xml\" -F \"SAMPLE=@sample.xml\" -F \"EXPERIMENT=@experiment.xml\" -F \"RUN=@run.xml\" \"https://www.ebi.ac.uk/ena/submit/drop-box/submit/?auth=ENA%20\"" + ftp_user_name + "%20" + ftp_password
-	
-	# p = subprocess.Popen(cmd, stdout=subprocess.PIPE, cwd=out, shell=True)
-	receipt_xml = open(out+"/receipt.xml", 'w')
-	print "\nRunning curl command....\n"
-	p = subprocess.Popen(test_cmd, stdout=receipt_xml, cwd=out, shell=True)
-	(curl_output, err) = p.communicate()
+    test_cmd = "curl -k -F \"SUBMISSION=@submission.xml\" -F \"STUDY=@study.xml\" -F \"SAMPLE=@sample.xml\" -F \"EXPERIMENT=@experiment.xml\" -F \"RUN=@run.xml\" \"https://www-test.ebi.ac.uk/ena/submit/drop-box/submit/?auth=ENA%20\"" + ftp_user_name + "%20" + ftp_password
+    prod_cmd = "\ncurl -k -F \"SUBMISSION=@submission.xml\" -F \"STUDY=@study.xml\" -F \"SAMPLE=@sample.xml\" -F \"EXPERIMENT=@experiment.xml\" -F \"RUN=@run.xml\" \"https://www.ebi.ac.uk/ena/submit/drop-box/submit/?auth=ENA%20\"" + ftp_user_name + "%20" + ftp_password
 
-	if "success=\"false\"" in open(out+"/receipt.xml").read():
-		print "\nERROR: There is a problem with the submission.  Please check the file ", out+"/receipt.xml", "and correct the error and re-submit using the -curl command.\n"
-		sys.exit()
-	# elif "success=\"true\"" in open(out+"/receipt.xml").read():
-	# 	print "\nTest submission is successfull!"
-	# 	print "\nSubmitting production now..."
-	# 	p = subprocess.Popen(prod_cmd, stdout=receipt_xml, cwd=out, shell=True)
-	# 	(curl_output, err) = p.communicate()
-	elif "success=\"true\"" in open(out+"/receipt.xml").read():
-		print "\nSUCCESS! Your data is now ready to be uploaded to production.  Note that if you decide to upload your data to production then it would be very difficult to delete it.  So if you are happy with this then run the following command:\n "+prod_cmd
+    # p = subprocess.Popen(cmd, stdout=subprocess.PIPE, cwd=out, shell=True)
+    receipt_xml = open(out + "/receipt.xml", 'w')
+    print "\nRunning curl command....\n"
+    p = subprocess.Popen(test_cmd, stdout=receipt_xml, cwd=out, shell=True)
+    (curl_output, err) = p.communicate()
 
-		print "\n NOTE: you must run the above curl command from the output dir which contains all the xml files."
+    if "success=\"false\"" in open(out + "/receipt.xml").read():
+        print "\nERROR: There is a problem with the submission.  Please check the file ", out + "/receipt.xml", "and correct the error and re-submit using the -curl command.\n"
+        sys.exit()
+    # elif "success=\"true\"" in open(out+"/receipt.xml").read():
+    # 	print "\nTest submission is successfull!"
+    # 	print "\nSubmitting production now..."
+    # 	p = subprocess.Popen(prod_cmd, stdout=receipt_xml, cwd=out, shell=True)
+    # 	(curl_output, err) = p.communicate()
+    elif "success=\"true\"" in open(out + "/receipt.xml").read():
+        print "\nSUCCESS! Your data is now ready to be uploaded to production.  Note that if you decide to upload your data to production then it would be very difficult to delete it.  So if you are happy with this then run the following command:\n " + prod_cmd
+
+        print "\n NOTE: you must run the above curl command from the output dir which contains all the xml files."

--- a/modules/populate_data_to_ENA.py
+++ b/modules/populate_data_to_ENA.py
@@ -48,6 +48,7 @@ def check_data_file(data_file):
     ------
     None
     """
+
     meta_data_file = file(data_file, 'U')
     # the data file should have this heading...
     data_file_heading = ['sample_name', 'taxon', 'organism', 'description']
@@ -86,6 +87,7 @@ def check_abstract_file(title_and_abstract_file):
     ------
     None
     """
+
     try:
         with open(title_and_abstract_file, 'U') as f:
             lines = f.readlines()
@@ -118,6 +120,7 @@ def rchop(string, ending):
     string : str
         The original string without the ending part, e.g. 'sample'
     """
+
     if string.endswith(ending):
         string = string[:-len(ending)]
     return string
@@ -143,8 +146,8 @@ def create_checksums_file(dir_of_input_data, refname, filetype, fastq_ends):
     ------
     checksums_file, file : a checksum file will be created in the dir_of_input_data directory.
                            It would be called: refname_"checksums.md5".
-
     """
+
     try:
         if filetype == "fastq":
             files = glob.glob(dir_of_input_data + "/*" + fastq_ends[0])
@@ -205,7 +208,7 @@ def upload_data_to_ena_ftp_server(dir_of_input_data, refname, ftp_user_name, ftp
     fastq_ends, tuple: Tuple of strings of size 2 with fastq files end, e.g. ('.R1.fastq.gz', '.R2.fastq.gz')
 
     return
-    ------   
+    ------
     None
     """
 
@@ -333,12 +336,9 @@ def create_dict_with_data(dir_of_input_data, refname, data_file, fastq_ends, hea
     header, True or False :  if True the first line will be considered a header line
     fastq_ends, tuple: Tuple of strings of size 2 with fastq files end, e.g. ('.R1.fastq.gz', '.R2.fastq.gz')
 
-
     return
     ------
-
     sample_id_and_data, dict : a dictionary that has the headings as keys and the data as values.
-
     """
 
     meta_data_file = file(data_file, 'U')
@@ -697,7 +697,7 @@ def study_xml(title_and_abstract_file, center_name, refname, out_dir):
     print "\nSuccessfully created study.xml file\n"
 
 
-def submission_xml(refname, center_name, out_dir, release=False, hold_date=''):
+def submission_xml(refname, center_name, out_dir, release=False, hold_date=None):
     """
     submission_xml(refname,center_name,out_dir,release,hold_date='')
     
@@ -733,7 +733,7 @@ def submission_xml(refname, center_name, out_dir, release=False, hold_date=''):
     # if a hold date is given until releasing publicly
     action = ET.SubElement(actions, "ACTION")
 
-    if hold_date:
+    if hold_date is not None:
         hold = ET.SubElement(action, "HOLD", HoldUntilDate=hold_date)
         del hold
     # else if release is given, i.e. release immediatley to the public
@@ -765,10 +765,8 @@ def run_curl_command(ftp_user_name, ftp_password, out):
 
     Params
     ------
-
     ftp_user_name, str: You must provide your ENA ftp username, e.g. Webin-40432
     ftp_password, str: You must provide your ENA ftp password
-   
 
     return
     ------

--- a/parse_receipt_xml_for_ena_submission.py
+++ b/parse_receipt_xml_for_ena_submission.py
@@ -9,17 +9,17 @@ import ast
 import xml.etree.ElementTree
 
 def set_up_argparse():
-	parser = argparse.ArgumentParser(description="""
+    parser = argparse.ArgumentParser(description="""
 
-	**This tool will take the receipt.xml file (output from the curl command used to submit all files to ENA repository) and create a csv file which will contain all the ENA accession numbers.**""")
+    **This tool will take the receipt.xml file (output from the curl command used to submit all files to ENA repository) and create a csv file which will contain all the ENA accession numbers.**""")
 
-	# parser = argparse.ArgumentParser(epilog="Good luck! If your jobs breaks, don't blame me :-)", add_help=True)
-	
-	parser.add_argument('--input_receipt_xml_file', '-i', help='please provide the path for the receipt.xml file.',default="required")
-	parser.add_argument('--out_dir', '-o', help='please provide the path to the output directory.')
-	opts = parser.parse_args()
-	
-	return opts
+    # parser = argparse.ArgumentParser(epilog="Good luck! If your jobs breaks, don't blame me :-)", add_help=True)
+
+    parser.add_argument('--input_receipt_xml_file', '-i', help='please provide the path for the receipt.xml file.',default="required")
+    parser.add_argument('--out_dir', '-o', help='please provide the path to the output directory.')
+    opts = parser.parse_args()
+
+    return opts
 
 def extract_ena_accession_from_receipt_xml(receipt_xml_file,out_dir):
 
@@ -33,17 +33,17 @@ def extract_ena_accession_from_receipt_xml(receipt_xml_file,out_dir):
 
     project_number = ""
     for study in studies:
-	    project_number = study.attributes['accession'].value
+        project_number = study.attributes['accession'].value
 
     for experiment in experiments:
         user_sample_names_and_ENA_numbers[experiment.attributes['accession'].value] = experiment.attributes['alias'].value
     for run in runs:
-    	user_sample_names_and_ENA_numbers[run.attributes['accession'].value] = run.attributes['alias'].value
+        user_sample_names_and_ENA_numbers[run.attributes['accession'].value] = run.attributes['alias'].value
     for sample in samples:
-    	user_sample_names_and_ENA_numbers[sample.attributes['accession'].value] = sample.attributes['alias'].value
+        user_sample_names_and_ENA_numbers[sample.attributes['accession'].value] = sample.attributes['alias'].value
 
     for key,value in user_sample_names_and_ENA_numbers.items():
-		final_dict[value].append(key)
+        final_dict[value].append(key)
 
     outfile = open(out_dir+"/"+project_number+"_data.csv", 'w')
     outfile.write("ID," + "Run accession," + "Study accession," + "Experiment accession\n" )
@@ -52,7 +52,7 @@ def extract_ena_accession_from_receipt_xml(receipt_xml_file,out_dir):
 
 def main(opts):
 
-	extract_ena_accession_from_receipt_xml(opts.input_receipt_xml_file,opts.out_dir)
+    extract_ena_accession_from_receipt_xml(opts.input_receipt_xml_file,opts.out_dir)
 
 if __name__ == '__main__':
     opts = set_up_argparse()


### PR DESCRIPTION
Add --fastq-end option to allow user to use different fastq files ends besides sample.R1.fastq.gz sample.R2.fastq.gz
Use only tabular separated files instead of a mixture of tab and csv files